### PR TITLE
Improvement to UI and Looper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,9 @@ import {
 } from '@/core/looperBindings';
 import { loadLooperStore, saveLooperStore } from '@/core/looperTriggers';
 import { useLooperTriggers } from '@/hooks/useLooperTriggers';
+import { useLooperHotkeys } from '@/hooks/useLooperHotkeys';
+import { barSecondsFromTempo } from '@/core/looperTransport';
+import { SIGNATURES } from '@/core/drumMachine';
 import { PRSTDecoder } from '@/core/PRSTDecoder';
 import { PRSTEncoder } from '@/core/PRSTEncoder';
 import { pushPresetToDevice, type PushProgress } from '@/core/devicePush';
@@ -85,6 +88,16 @@ function App() {
   // Practice drum machine: lives here (not in a drawer) so the beat keeps
   // playing while the drawer is closed and across the phone/desktop swap.
   const drumMachine = useDrumMachine(audioEngine);
+  // Keyboard transport for the loop station. Bound at the window rather than in
+  // the drawer: the loop plays on with the drawer closed, so the keys must too.
+  useLooperHotkeys(looper, looper.ready);
+  // One drum-machine bar, offered to the looper as a grid to lock its own bar
+  // to , the only way to get a loop length with no human reaction time in it.
+  // Steps are 16ths in every signature, so a bar is steps/4 quarter-note beats.
+  const drumBarSeconds = barSecondsFromTempo(
+    drumMachine.bpm,
+    SIGNATURES[drumMachine.signature].steps / 4,
+  );
 
   // Loop-station hardware bindings. State drives the LooperPanel UI; the ref
   // mirror is what the once-per-connection MIDI callbacks read (so they see the
@@ -782,6 +795,11 @@ function App() {
     onOpenGuide: openGuide,
     onPanelOpen: trackPanelOpen,
     looper: looper,
+    looperTempo: {
+      bpm: drumMachine.bpm,
+      barSeconds: drumBarSeconds,
+      label: `${drumMachine.bpm} BPM · ${drumMachine.signature}`,
+    },
     looperBindings: looperBindings,
     onLooperBindingsChange: setLooperBindings,
     onLooperDrawerOpenChange: (open) => {

--- a/src/audio/looper-recorder.worklet.js
+++ b/src/audio/looper-recorder.worklet.js
@@ -1,7 +1,9 @@
 // AudioWorklet processor that taps its single input and streams raw Float32 PCM
 // (all input channels averaged to mono) to the main thread. Runs on the audio
-// render thread for sample-accurate capture; the loop station assembles the
-// posted chunks into an AudioBuffer. Pure sink: it produces no output.
+// render thread, which is the only place a loop's edges can be placed exactly:
+// a setTimeout on the main thread is late by however long the UI is busy, and
+// the board's rAF work makes that tens of milliseconds. Every decision about
+// WHEN a take starts and stops therefore lives here, driven by `currentFrame`.
 //
 // The downmix must cover every channel: the GP-200 captures as a stereo USB
 // stream and can carry the signal on only one side, so recording a fixed
@@ -13,42 +15,321 @@
 // emitted asset (never inlined as a data: URL) by vite.config's assetsInlineLimit
 // override, because Chromium's addModule() rejects data: URLs.
 //
-// Control protocol (main thread → processor, via port.postMessage):
-//   { type: 'start' }  begin forwarding frames
-//   { type: 'stop' }   stop forwarding
-// Data protocol (processor → main thread):
-//   { type: 'chunk', samples: Float32Array }   one render quantum of input
+// ── Control protocol (main thread → processor) ──────────────────────────────
+//   { type: 'arm', mode: 'frame', startFrame, bodyFrames, tailFrames }
+//       capture begins exactly at `startFrame` (context frames). bodyFrames > 0
+//       stops the take by itself after that many frames , a fixed-length take,
+//       which is the only way to get a loop with no human reaction time in it.
+//   { type: 'arm', mode: 'level', threshold, prerollFrames, holdQuanta,
+//     bodyFrames, tailFrames }
+//       capture begins on the first note: the processor keeps a rolling
+//       pre-roll so the attack that TRIGGERED it is still in the recording.
+//   { type: 'stop', stopFrame }
+//       end the body at exactly `stopFrame`, then keep capturing the tail. The
+//       caller pushes that frame out by the same latency it pushed the start
+//       by, so a hand-stopped take is exactly as long as the gap between the
+//       two button presses instead of one round trip short.
+//   { type: 'cancel' }   abandon everything, emit nothing
+//
+// ── Data protocol (processor → main thread) ─────────────────────────────────
+//   { type: 'started', startFrame, prerollFrames }
+//       capture is running. `prerollFrames` is how many of the frames already
+//       posted sit BEFORE the level trigger (0 in frame mode).
+//   { type: 'chunk', samples }   PCM, in order, body first then tail
+//   { type: 'ended', bodyFrames, tailFrames, reason }
+//       the take is complete: the first `bodyFrames` posted are the loop, the
+//       rest is the ring-out to be blended over its head.
+//
+// The tail is NOT an afterthought: the loop point is joined by summing that
+// ring-out back over the downbeat (see core/loopCapture.ts blendTail), so the
+// recorder has to stay open past the end of the loop to have anything to sum.
+
+/** Level has to hold for this many quanta before a 'level' arm fires, so a
+ *  cable pop or a single glitchy sample cannot start a take. */
+const DEFAULT_HOLD_QUANTA = 2;
+/** Once armed, hold-checking accepts anything above this fraction of the
+ *  threshold , the attack decays fast and must not have to re-cross. */
+const HOLD_RATIO = 0.5;
 
 class LooperRecorderProcessor extends AudioWorkletProcessor {
   constructor() {
     super();
-    this.recording = false;
-    this.port.onmessage = (event) => {
-      const msg = event.data;
-      if (msg && msg.type === 'start') this.recording = true;
-      else if (msg && msg.type === 'stop') this.recording = false;
-    };
+    this.resetState();
+    this.port.onmessage = (event) => this.handleMessage(event.data);
   }
 
-  process(inputs) {
-    if (!this.recording) return true;
-    const channels = inputs[0];
-    if (!channels || channels.length === 0) return true;
-    const firstChannel = channels[0];
-    if (!firstChannel || firstChannel.length === 0) return true;
-    // Copy into a fresh transferable buffer; the input arrays are reused by
-    // the engine after process() returns, so we must not post them directly.
-    const samples = new Float32Array(firstChannel.length);
-    samples.set(firstChannel);
+  resetState() {
+    this.state = 'idle'; // idle | waiting | recording | tail
+    this.mode = 'frame';
+    this.startFrame = 0;
+    this.threshold = 0;
+    this.holdQuanta = DEFAULT_HOLD_QUANTA;
+    this.bodyTarget = 0; // 0 = run until stopped
+    this.stopFrame = 0; // 0 = no stop scheduled
+    this.tailTarget = 0;
+    this.bodyFrames = 0;
+    this.tailFrames = 0;
+    this.ring = null;
+    this.ringWrite = 0;
+    this.ringFilled = 0;
+    this.crossPending = false;
+    this.framesSinceCross = 0;
+    this.holdSeen = 0;
+    this.endReason = 'stop';
+  }
+
+  handleMessage(msg) {
+    if (!msg) return;
+    if (msg.type === 'arm') {
+      this.resetState();
+      this.mode = msg.mode === 'level' ? 'level' : 'frame';
+      this.startFrame = msg.startFrame || 0;
+      this.threshold = msg.threshold || 0;
+      this.holdQuanta = msg.holdQuanta || DEFAULT_HOLD_QUANTA;
+      this.bodyTarget = Math.max(0, msg.bodyFrames || 0);
+      this.tailTarget = Math.max(0, msg.tailFrames || 0);
+      if (this.mode === 'level') {
+        // Always at least one render quantum, so a trigger always has a ring to
+        // report its start frame against.
+        const preroll = Math.max(128, msg.prerollFrames || 0);
+        this.ring = new Float32Array(preroll);
+      }
+      this.state = 'waiting';
+      return;
+    }
+    if (msg.type === 'stop') {
+      if (this.state === 'recording') this.stopFrame = Math.max(1, msg.stopFrame || 1);
+      else if (this.state === 'waiting') this.cancel();
+      return;
+    }
+    if (msg.type === 'cancel') this.cancel();
+  }
+
+  cancel() {
+    const wasActive = this.state !== 'idle';
+    this.resetState();
+    if (wasActive) this.port.postMessage({ type: 'cancelled' });
+  }
+
+  /** Move from body to tail, ending the take outright when no tail is wanted. */
+  finishBody(reason) {
+    this.endReason = reason;
+    if (this.tailTarget > 0) {
+      this.state = 'tail';
+      return;
+    }
+    this.emitEnded(reason);
+  }
+
+  emitEnded(reason) {
+    const bodyFrames = this.bodyFrames;
+    const tailFrames = this.tailFrames;
+    this.resetState();
+    this.port.postMessage({ type: 'ended', bodyFrames, tailFrames, reason });
+  }
+
+  /** Post a copy of `samples` (optionally a slice) as one chunk. */
+  emit(samples, from, to) {
+    const start = from || 0;
+    const end = to === undefined ? samples.length : to;
+    if (end <= start) return 0;
+    const chunk = new Float32Array(end - start);
+    chunk.set(samples.subarray(start, end));
+    // Read the length BEFORE posting: transferring the buffer detaches it, and
+    // a detached Float32Array reports length 0. Counting frames off the posted
+    // chunk is how the fixed-length stop silently never fired.
+    const length = chunk.length;
+    this.port.postMessage({ type: 'chunk', samples: chunk }, [chunk.buffer]);
+    return length;
+  }
+
+  /** Average every input channel of this render quantum into one array. */
+  downmix(channels) {
+    const first = channels[0];
+    const mono = new Float32Array(first.length);
+    mono.set(first);
     for (let ch = 1; ch < channels.length; ch++) {
       const channel = channels[ch];
-      for (let i = 0; i < samples.length; i++) samples[i] += channel[i];
+      for (let i = 0; i < mono.length; i++) mono[i] += channel[i];
     }
     if (channels.length > 1) {
       const scale = 1 / channels.length;
-      for (let i = 0; i < samples.length; i++) samples[i] *= scale;
+      for (let i = 0; i < mono.length; i++) mono[i] *= scale;
     }
-    this.port.postMessage({ type: 'chunk', samples }, [samples.buffer]);
+    return mono;
+  }
+
+  writeRing(mono) {
+    const ring = this.ring;
+    if (!ring || ring.length === 0) return;
+    for (let i = 0; i < mono.length; i++) {
+      ring[this.ringWrite] = mono[i];
+      this.ringWrite = (this.ringWrite + 1) % ring.length;
+      if (this.ringFilled < ring.length) this.ringFilled++;
+    }
+  }
+
+  /** Emit the pre-roll in chronological order and return how many frames went out. */
+  flushRing() {
+    const ring = this.ring;
+    if (!ring || this.ringFilled === 0) return 0;
+    const oldest = (this.ringWrite - this.ringFilled + ring.length) % ring.length;
+    let sent = 0;
+    if (oldest + this.ringFilled <= ring.length) {
+      sent += this.emit(ring, oldest, oldest + this.ringFilled);
+    } else {
+      sent += this.emit(ring, oldest, ring.length);
+      sent += this.emit(ring, 0, this.ringFilled - (ring.length - oldest));
+    }
+    return sent;
+  }
+
+  /** First sample index in this quantum at or above `threshold`, or -1. */
+  firstCrossing(mono, level) {
+    for (let i = 0; i < mono.length; i++) {
+      if (Math.abs(mono[i]) >= level) return i;
+    }
+    return -1;
+  }
+
+  /** Start the body here; `offset` is where inside this quantum it begins. */
+  beginRecording(mono, offset, prerollFrames) {
+    this.state = 'recording';
+    this.bodyFrames = prerollFrames;
+    this.port.postMessage({
+      type: 'started',
+      startFrame: currentFrame + offset - prerollFrames,
+      prerollFrames,
+    });
+    this.consumeBody(mono, offset);
+  }
+
+  /**
+   * Feed one quantum (from `offset`) into the body, spilling into the tail once
+   * a fixed length is reached. Splitting inside the quantum is what makes a
+   * fixed-length take exact rather than rounded up to a render block.
+   */
+  consumeBody(mono, offset) {
+    const start = offset;
+    let limit = mono.length;
+    let ending = null;
+    // A scheduled stop and a fixed length are the same kind of edge: whichever
+    // lands first inside this quantum ends the body there, mid-block, which is
+    // what keeps both exact instead of rounded up to a render quantum.
+    if (this.stopFrame > 0) {
+      const untilStop = this.stopFrame - (currentFrame + start);
+      if (untilStop <= limit - start) {
+        limit = start + Math.max(0, untilStop);
+        ending = 'stop';
+      }
+    }
+    if (this.bodyTarget > 0) {
+      const remaining = this.bodyTarget - this.bodyFrames;
+      if (remaining <= limit - start) {
+        limit = start + remaining;
+        ending = 'length';
+      }
+    }
+    this.bodyFrames += this.emit(mono, start, limit);
+    if (!ending) return;
+    this.finishBody(ending);
+    if (this.state === 'tail') this.consumeTail(mono, limit);
+  }
+
+  consumeTail(mono, offset) {
+    const remaining = this.tailTarget - this.tailFrames;
+    if (remaining <= 0) {
+      this.emitEnded(this.endReason);
+      return;
+    }
+    const take = Math.min(remaining, mono.length - offset);
+    this.tailFrames += this.emit(mono, offset, offset + take);
+    if (this.tailFrames >= this.tailTarget) this.emitEnded(this.endReason);
+  }
+
+  /** Level-armed: fill the pre-roll and decide whether this quantum triggers. */
+  watchForLevel(mono) {
+    const crossing = this.firstCrossing(mono, this.threshold);
+    if (!this.crossPending) {
+      if (crossing < 0) {
+        this.writeRing(mono);
+        return;
+      }
+      // Remember where the crossing sits so the pre-roll reported to the main
+      // thread points at the attack itself, not at the end of the hold window.
+      this.crossPending = true;
+      this.holdSeen = 1;
+      this.framesSinceCross = mono.length - crossing;
+      this.writeRing(mono);
+      if (this.holdSeen >= this.holdQuanta) this.triggerFromRing(mono);
+      return;
+    }
+    const held = this.firstCrossing(mono, this.threshold * HOLD_RATIO) >= 0;
+    if (!held) {
+      // A pop, not a note: forget it and keep listening.
+      this.crossPending = false;
+      this.holdSeen = 0;
+      this.framesSinceCross = 0;
+      this.writeRing(mono);
+      return;
+    }
+    this.holdSeen++;
+    this.framesSinceCross += mono.length;
+    this.writeRing(mono);
+    if (this.holdSeen >= this.holdQuanta) this.triggerFromRing(mono);
+  }
+
+  /**
+   * Fire a level-armed take. Everything the ring holds is emitted first, so the
+   * body already contains the attack (and a little air before it); the main
+   * thread refines the exact start inside that pre-roll.
+   */
+  triggerFromRing(mono) {
+    const sent = this.flushRing();
+    const beforeCross = Math.max(0, sent - this.framesSinceCross);
+    this.state = 'recording';
+    this.bodyFrames = sent;
+    // The ring was just topped up with this quantum, so its oldest frame sits
+    // `sent` frames before the END of the current block.
+    this.port.postMessage({
+      type: 'started',
+      startFrame: currentFrame + mono.length - sent,
+      prerollFrames: beforeCross,
+    });
+    // The quantum that completed the hold is already in the ring, so there is
+    // nothing left to consume here , but a very short fixed length could
+    // already be satisfied by the pre-roll alone.
+    if (this.bodyTarget > 0 && this.bodyFrames >= this.bodyTarget) {
+      this.finishBody('length');
+    }
+  }
+
+  process(inputs) {
+    if (this.state === 'idle') return true;
+    const channels = inputs[0];
+    if (!channels || channels.length === 0) return true;
+    const first = channels[0];
+    if (!first || first.length === 0) return true;
+    const mono = this.downmix(channels);
+
+    if (this.state === 'waiting') {
+      if (this.mode === 'level') {
+        this.watchForLevel(mono);
+        return true;
+      }
+      const end = currentFrame + mono.length;
+      if (end <= this.startFrame) return true;
+      const offset = Math.max(0, this.startFrame - currentFrame);
+      this.beginRecording(mono, offset, 0);
+      return true;
+    }
+
+    if (this.state === 'recording') {
+      this.consumeBody(mono, 0);
+      return true;
+    }
+
+    this.consumeTail(mono, 0);
     return true;
   }
 }

--- a/src/components/Guide.tsx
+++ b/src/components/Guide.tsx
@@ -445,13 +445,77 @@ export function Guide({ onBack }: GuideProps) {
               Stacking layers
             </h3>
             <p>
-              Your first recording sets the master loop length. Every record pass
-              after that adds a new layer, quantized and phase-locked to the
-              first, with no limit on the number of layers , so the tenth
+              Every record pass adds a new layer, quantized and phase-locked to
+              the loop, with no limit on the number of layers , so the tenth
               overdub is still exactly in time with the first. Each track has its
               own <strong>Play / Mute / level / delete</strong>, and there's a
               master progress bar, a master level, and <strong>Clear All</strong>.
               You can also import an audio file as a layer to jam over.
+            </p>
+            <h3 className="font-mono-display text-base font-bold tracking-wide text-text-primary mt-6">
+              Starting and stopping in time
+            </h3>
+            <p>
+              Everything that decides where a take begins and ends lives under{' '}
+              <strong>RECORD SETUP</strong>, and it is worth two minutes before
+              your first loop:
+            </p>
+            <ul>
+              <li>
+                <strong>Loop grid.</strong> Hit <strong>LOCK BAR TO DRUMS</strong>{' '}
+                and the looper's bar becomes one bar of the practice drum
+                machine's tempo , an exact length, rather than one measured
+                between two of your own button presses.
+              </li>
+              <li>
+                <strong>Take length.</strong> Pick a bar count and recording{' '}
+                <em>stops itself</em> at exactly that length. Nothing to press in
+                time, so no reaction time ends up in the loop. Leave it on FREE to
+                stop by hand.
+              </li>
+              <li>
+                <strong>Start on first note.</strong> With this on, your first
+                take doesn't begin when you press REC , it begins when you{' '}
+                <em>play</em>. The recorder keeps a rolling pre-roll, so the pick
+                attack that triggered it is still there rather than clipped off,
+                and the loop starts at a zero crossing. Set the trigger level
+                against the meter beside it: above your rig's hiss, below your
+                quietest intended note. Once a loop is running, later takes drop
+                in on the downbeat instead, which is always the better reference.
+              </li>
+              <li>
+                <strong>Timing trim.</strong> The app already compensates for the
+                round trip your interface reports (shown in ms). If takes still
+                land consistently late, raise the trim; if they land early, lower
+                it. It is remembered per browser.
+              </li>
+            </ul>
+            <h3 className="font-mono-display text-base font-bold tracking-wide text-text-primary mt-6">
+              How the loop point is joined
+            </h3>
+            <p>
+              The downbeat is usually the loudest thing in a take, so fading it in
+              , which is what a plain crossfade does , is exactly what makes a
+              loop sound like it is breathing. This looper never touches the head.
+              Instead it keeps recording <em>past</em> the end of the loop and
+              mixes that ring-out back over the downbeat, so the last chord
+              carries across the wrap the way it would if you had kept playing.{' '}
+              <strong>LOOP JOIN</strong> sets how much: raise it if the wrap sounds
+              cut off, lower it if the last chord smears over the top of the loop.
+            </p>
+            <h3 className="font-mono-display text-base font-bold tracking-wide text-text-primary mt-6">
+              Keyboard
+            </h3>
+            <p>
+              <strong>R</strong> records and stops, <strong>SPACE</strong> plays and
+              stops everything, <strong>Ctrl/⌘ Z</strong> undoes , and mid-take it
+              throws away the pass in progress, which is the one thing you always
+              want in a hurry. <strong>Ctrl/⌘ ⇧ Z</strong> redoes,{' '}
+              <strong>M</strong> mutes the selected track,{' '}
+              <strong>[</strong> and <strong>]</strong> step through tracks, and{' '}
+              <strong>DEL</strong> deletes the selected one (undoable). They work
+              anywhere in the app while capture is on, even with the drawer closed,
+              and stand down while you're typing in a field.
             </p>
             <h3 className="font-mono-display text-base font-bold tracking-wide text-text-primary mt-6">
               Hands-free from the pedal

--- a/src/components/board/LooperAdvanced.tsx
+++ b/src/components/board/LooperAdvanced.tsx
@@ -1,0 +1,365 @@
+import { useState } from 'react';
+import type { LooperApi } from '@/hooks/useLooper';
+import {
+  type LooperBindings,
+  type LooperActionKind,
+  type ExpTarget,
+} from '@/core/looperBindings';
+import { Button } from '@/components/ui/Button';
+import { LooperTimeline } from '@/components/board/LooperTimeline';
+import { LooperSetup, type LooperTempo } from '@/components/board/LooperSetup';
+import {
+  LooperImportButton,
+  LooperInputMeter,
+  LooperMasterLevel,
+  LooperTrackList,
+} from '@/components/board/LooperControls';
+import { LooperStomps } from '@/components/board/LooperStomps';
+import { fmtCycle, playAllLabel, recordButtonState } from '@/components/board/looperLabels';
+import type { LooperTriggerMap } from '@/core/looperTriggers';
+import type { LearnNotice } from '@/hooks/useLooperTriggers';
+
+// The loop station's ADVANCED face: everything the simple one hides. Capture
+// edges (LooperSetup), footswitch learning, EXP routing and per-track
+// transport, on top of the same transport and track list the simple face uses.
+
+interface LooperAdvancedProps {
+  looper: LooperApi;
+  /** the practice drum machine's bar, offered as a grid to lock the loop to */
+  tempo: LooperTempo;
+  bindings: LooperBindings;
+  onBindingsChange: (next: LooperBindings) => void;
+  /* MIDI-learn: assign a hardware stomp to each transport action */
+  triggers: LooperTriggerMap;
+  armedAction: LooperActionKind | null;
+  onArmLearn: (action: LooperActionKind) => void;
+  onClearTrigger: (action: LooperActionKind) => void;
+  /** forget every assigned stomp at once */
+  onClearAll: () => void;
+  learnNotice: LearnNotice | null;
+  /** learning needs a connected GP-200 */
+  learnEnabled: boolean;
+}
+
+const SELECT_CLASS =
+  'bg-bg-primary border border-border-active rounded px-2 py-1 ' +
+  'font-mono-display text-caption text-text-secondary';
+
+
+
+
+
+
+/** One line of "what this take will do", so the setup drawer can stay shut. */
+function setupSummary(looper: LooperApi): string {
+  const parts: string[] = [];
+  if (looper.baseDurationSec === null) parts.push('bar not set');
+  else parts.push(`bar ${looper.baseDurationSec.toFixed(2)}s`);
+  if (looper.baseLocked) parts.push('locked to drums');
+  if (looper.settings.recordBars === null) parts.push('free length');
+  else parts.push(`${looper.settings.recordBars}-bar takes`);
+  if (looper.settings.autoStart) parts.push('starts on first note');
+  parts.push(`join ${looper.settings.tailBlendMs}ms`);
+  if (looper.settings.latencyTrimMs !== 0) parts.push(`trim ${looper.settings.latencyTrimMs}ms`);
+  return parts.join(' · ');
+}
+
+function expValue(target: ExpTarget): string {
+  if (target === null) return 'none';
+  if (target.kind === 'masterGain') return 'master';
+  return 'selected';
+}
+
+export function LooperAdvanced({
+  looper,
+  tempo,
+  bindings,
+  onBindingsChange,
+  triggers,
+  armedAction,
+  onArmLearn,
+  onClearTrigger,
+  onClearAll,
+  learnNotice,
+  learnEnabled,
+}: LooperAdvancedProps) {
+  const [importError, setImportError] = useState<string | null>(null);
+  const [setupOpen, setSetupOpen] = useState(!looper.hasContent);
+  const button = recordButtonState(looper);
+  const noTracks = looper.tracks.length === 0;
+
+  const updateExpTarget = (target: ExpTarget) => {
+    onBindingsChange({ ...bindings, expTarget: target });
+  };
+
+  let trackReadout = '-/-';
+  const selectedPosition = looper.tracks.findIndex(
+    (trackRow) => trackRow.id === looper.selectedTrack,
+  );
+  if (selectedPosition >= 0) {
+    trackReadout = `${selectedPosition + 1}/${looper.tracks.length}`;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Collapsible primer on the dynamic-track workflow */}
+      <details className="group">
+        <summary
+          className="font-mono-display text-label text-text-muted uppercase
+            tracking-widest cursor-pointer select-none list-none"
+        >
+          <span className="group-open:hidden">▸ How the looper works</span>
+          <span className="hidden group-open:inline">▾ How the looper works</span>
+        </summary>
+        <ul
+          className="font-mono-display text-caption text-text-muted mt-2 pl-4
+            flex flex-col gap-1 list-disc"
+        >
+          <li>
+            Records the GP-200&apos;s USB audio here in the browser , separate from
+            the pedal&apos;s built-in looper, which is the collapsed section at the
+            bottom of this drawer.
+          </li>
+          <li>
+            <strong>Set the bar first.</strong> LOCK BAR TO DRUMS (in RECORD
+            SETUP) takes the practice drum machine&apos;s tempo, so the loop length is
+            exact. Otherwise the first thing in sets it , an imported file&apos;s own
+            length, or your first take, stop-press reaction time and all.
+          </li>
+          <li>
+            ● REC starts a NEW track. With START ON FIRST NOTE on, the first take
+            waits for you to actually play and begins on the attack , the pick
+            itself is kept, not clipped. Once a loop is running, takes drop in on
+            the downbeat instead (◌ ARMED). Set a TAKE LENGTH in bars and the
+            recorder stops itself, sample-exact, with nothing to press in time.
+          </li>
+          <li>
+            The loop point is joined by mixing the ring-out captured PAST the end
+            back over the downbeat , the downbeat is never faded in. LOOP JOIN
+            sets how much: raise it if the wrap sounds cut off, lower it if the
+            last chord smears over the top of the loop.
+          </li>
+          <li>
+            If takes land consistently late or early, nudge TIMING TRIM. The app
+            already compensates for the round trip your interface reports; the
+            trim covers whatever that number misses.
+          </li>
+          <li>
+            The loop is as long as the LONGEST take. Play past the end and it
+            grows another bar; shorter tracks simply repeat underneath , you can
+            see the repeats ghosted in the timeline.
+          </li>
+          <li>
+            VOLUME is the loop station&apos;s own output. Tracks sum, so stacking
+            takes gets loud fast , a soft clipper keeps the mix from breaking
+            up, but the level is still yours to set.
+          </li>
+          <li>
+            ▶ PLAY stops or restarts all tracks together. ◀ / ▶ move the
+            selected track (highlighted row) , that&apos;s the track the EXP pedal&apos;s
+            &quot;Selected track level&quot; controls.
+          </li>
+          <li>
+            <strong>Keys beat mice mid-phrase.</strong> R records, SPACE plays and
+            stops, and Ctrl+Z throws away the take in progress (or steps back
+            through finished ones). Full list in RECORD SETUP.
+          </li>
+          <li>
+            Footswitches below: click the action you want, then step on any
+            switch , that switch is remembered on this machine. Give the looper
+            switches that do nothing else on the pedal (CTRL / TAP set to None);
+            see the warning below for why.
+          </li>
+        </ul>
+      </details>
+
+      {/* Transport: the same controls the footswitch bindings target. REC/PLAY
+          grow to fill narrow screens (primary touch targets); the track
+          selector and Clear All wrap onto their own line when tight. */}
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant={button.variant}
+            size="sm"
+            className="flex-1 sm:flex-none"
+            onClick={looper.toggleRecord}
+            title={button.hint}
+          >
+            {button.label}
+          </Button>
+          {button.live && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={looper.cancelRecord}
+              title="Throw this take away and keep everything else (Ctrl+Z)"
+            >
+              ✕ CANCEL
+            </Button>
+          )}
+          <LooperImportButton
+            looper={looper}
+            onError={setImportError}
+            className="flex-1 sm:flex-none"
+          />
+          {looper.isRecording && (
+            <LooperInputMeter barClassName="w-16 sm:w-20" />
+          )}
+          <Button
+            variant="secondary"
+            size="sm"
+            className="flex-1 sm:flex-none"
+            disabled={noTracks}
+            onClick={looper.togglePlayAll}
+            title="Play all tracks / stop all tracks"
+          >
+            {playAllLabel(looper.anyPlaying)}
+          </Button>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={noTracks}
+              onClick={looper.selectPrevTrack}
+              title="Select previous track"
+            >
+              ◀
+            </Button>
+            <span
+              className="font-mono-display text-caption text-text-secondary tabular-nums
+                w-12 text-center"
+            >
+              {trackReadout}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={noTracks}
+              onClick={looper.selectNextTrack}
+              title="Select next track"
+            >
+              ▶
+            </Button>
+          </div>
+          <div className="flex items-center gap-1 ml-auto">
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={!looper.canUndo && !button.live}
+              onClick={looper.undo}
+              title="Undo , cancels the take in progress, otherwise steps back one (Ctrl+Z)"
+            >
+              ↶ UNDO
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!looper.canRedo}
+              onClick={looper.redo}
+              title="Redo (Ctrl+Shift+Z)"
+            >
+              ↷
+            </Button>
+            <Button variant="danger" size="sm" disabled={noTracks} onClick={looper.clearAll}>
+              Clear All
+            </Button>
+          </div>
+        </div>
+        {/* The length model, stated plainly: bars, total, and one bar's worth */}
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-mono-display text-label text-text-muted uppercase tracking-widest">
+            LOOP
+          </span>
+          <span className="font-mono-display text-caption text-text-secondary tabular-nums">
+            {fmtCycle(looper.cycleBars, looper.cycleDurationSec, looper.baseDurationSec)}
+          </span>
+        </div>
+      </div>
+
+      <LooperMasterLevel
+        level={looper.settings.masterLevel}
+        onChange={(level) => looper.updateSettings({ masterLevel: level })}
+      />
+
+      {/* Capture settings: the four things that decide whether a loop lands in
+          time and wraps cleanly. Open by default until the first take exists,
+          because that is exactly when they matter and nobody goes looking for
+          a collapsed panel before their loop sounds wrong. */}
+      <details
+        className="rounded-lg border border-border-active bg-bg-deep/40"
+        open={setupOpen}
+        onToggle={(event) => setSetupOpen(event.currentTarget.open)}
+      >
+        <summary
+          className="px-3 py-2 cursor-pointer select-none list-none flex flex-wrap
+            items-baseline gap-x-3 gap-y-1"
+        >
+          <span
+            className="font-mono-display text-label text-text-secondary uppercase
+              tracking-widest"
+          >
+            ⚙ Record setup
+          </span>
+          <span className="font-mono-display text-caption text-text-muted">
+            {setupSummary(looper)}
+          </span>
+        </summary>
+        <div className="px-3 pb-3">
+          <LooperSetup looper={looper} tempo={tempo} />
+        </div>
+      </details>
+
+      {importError && (
+        <p
+          className="font-mono-display text-caption text-accent-red px-3 py-2 rounded-lg
+            border border-accent-red bg-accent-red/10"
+        >
+          {importError}
+        </p>
+      )}
+
+      {/* The visual: waveform lanes across the cycle with a shared playhead */}
+      <LooperTimeline looper={looper} />
+
+      {/* Track rows: the control surface for what the timeline shows */}
+      <LooperTrackList looper={looper} />
+
+      {/* Footswitch assignments (compact grid) + what the EXP pedal drives. */}
+      <div className="pt-2 border-t border-border-active flex flex-col gap-3">
+        <LooperStomps
+          triggers={triggers}
+          armedAction={armedAction}
+          onArmLearn={onArmLearn}
+          onClearTrigger={onClearTrigger}
+          onClearAll={onClearAll}
+          learnNotice={learnNotice}
+          learnEnabled={learnEnabled}
+          verbose
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono-display text-label text-text-secondary w-16">EXP →</span>
+          <select
+            value={expValue(bindings.expTarget)}
+            onChange={(event) => {
+              const picked = event.target.value;
+              if (picked === 'none') updateExpTarget(null);
+              else if (picked === 'master') updateExpTarget({ kind: 'masterGain' });
+              else updateExpTarget({ kind: 'selectedTrackGain' });
+            }}
+            className={`flex-1 sm:flex-none min-w-0 ${SELECT_CLASS}`}
+          >
+            <option value="none">-</option>
+            <option value="master">Master level</option>
+            <option value="selected">Selected track level</option>
+          </select>
+          <span
+            className="font-mono-display text-caption text-text-muted basis-full
+              sm:basis-auto"
+          >
+            (EXP wire format pending capture)
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/board/LooperControls.tsx
+++ b/src/components/board/LooperControls.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAudioEngine } from '@/components/AudioEngineProvider';
+import { Button } from '@/components/ui/Button';
+import { Led } from '@/components/ui/Badge';
+import type { LooperApi } from '@/hooks/useLooper';
+import { track as trackEvent } from '@/core/analytics';
+import { fileExt } from '@/core/analyticsEvents';
+
+// Presentational pieces the loop station's SIMPLE and ADVANCED faces both
+// render. Anything that appears on both lives here rather than being written
+// twice , the two faces are meant to differ in how much they show, never in
+// how the same control behaves.
+
+/** Audio containers worth offering; the browser decodes whatever it supports. */
+const IMPORT_ACCEPT = 'audio/*,.wav,.mp3,.ogg,.flac,.m4a,.aac';
+
+interface LooperMasterLevelProps {
+  level: number;
+  onChange: (level: number) => void;
+}
+
+/**
+ * The loop station's output level.
+ *
+ * Every take stacks its full level onto the mix, so without this the third
+ * overdub is three times as loud as the first and the browser hard-clips the
+ * difference. It sits on the main surface in both faces for that reason ,
+ * this is not a setup detail, it is the volume knob.
+ */
+export function LooperMasterLevel({ level, onChange }: LooperMasterLevelProps) {
+  const percent = Math.round(level * 100);
+  return (
+    <div
+      className="flex items-center gap-3 px-3 py-2.5 rounded-lg border
+        border-border-active bg-bg-hover"
+    >
+      <span
+        className="font-mono-display text-label text-text-secondary uppercase
+          tracking-widest shrink-0"
+      >
+        Volume
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.01}
+        value={level}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="flex-1 min-w-0 accent-accent-amber"
+        aria-label="Loop station output level"
+      />
+      <span
+        className="font-mono-display text-caption text-text-secondary tabular-nums
+          w-10 text-right shrink-0"
+      >
+        {percent}%
+      </span>
+    </div>
+  );
+}
+
+interface LooperImportButtonProps {
+  looper: LooperApi;
+  /** the decode error, reported up so each face can place it in its own layout */
+  onError: (message: string | null) => void;
+  className?: string;
+}
+
+/** Pick an audio file and add it as a looping track. */
+export function LooperImportButton({ looper, onError, className = '' }: LooperImportButtonProps) {
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const handlePick = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset immediately so re-picking the SAME file still fires a change event.
+    event.target.value = '';
+    if (!file) return;
+    onError(null);
+    const error = await looper.importAudioFile(file);
+    onError(error);
+    // Safe to instrument at the call site (unlike record): import has no
+    // footswitch binding, so this is the only path in. Extension only , the
+    // filename itself is user data and never leaves the browser.
+    trackEvent('looper_import_audio', { ok: error === null, ext: fileExt(file.name) });
+  };
+
+  let label = '⭳ IMPORT';
+  if (looper.importing) label = 'DECODING…';
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="sm"
+        className={className}
+        disabled={looper.importing}
+        onClick={() => fileInput.current?.click()}
+        title="Import a backing track to play along to"
+      >
+        {label}
+      </Button>
+      <input
+        ref={fileInput}
+        type="file"
+        accept={IMPORT_ACCEPT}
+        className="hidden"
+        onChange={handlePick}
+      />
+    </>
+  );
+}
+
+interface LooperInputMeterProps {
+  /** width classes for the meter bar itself */
+  barClassName?: string;
+}
+
+/**
+ * Live input level, mounted only while a take is actually capturing.
+ *
+ * Same rAF-driven read the AudioMeters use, written straight to the DOM. A
+ * silent take , wrong input picked, amp muted , is otherwise impossible to
+ * tell from a good one until playback, by which point it has already cost you
+ * the phrase.
+ */
+export function LooperInputMeter({ barClassName = 'flex-1' }: LooperInputMeterProps) {
+  const fill = useRef<HTMLSpanElement>(null);
+  const { active, getLevels } = useAudioEngine();
+
+  useEffect(() => {
+    if (!active) return;
+    let raf = 0;
+    const tick = () => {
+      const { input } = getLevels();
+      if (fill.current) fill.current.style.width = `${(input * 100).toFixed(1)}%`;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [active, getLevels]);
+
+  return (
+    <span className="flex items-center gap-1.5" title="Live input level while recording">
+      <span className="font-mono-display text-caption text-accent-red">IN</span>
+      <span className={`h-3 rounded bg-bg-hover overflow-hidden ${barClassName}`}>
+        <span ref={fill} className="block h-full bg-accent-red" style={{ width: '0%' }} />
+      </span>
+    </span>
+  );
+}
+
+function trackRowClass(selected: boolean): string {
+  const base =
+    'flex flex-wrap items-center gap-2 px-3 py-2 rounded-lg border bg-bg-hover cursor-pointer';
+  if (selected) return `${base} border-accent-amber`;
+  return `${base} border-border-active`;
+}
+
+function playPauseLabel(state: string): string {
+  if (state === 'playing') return 'Pause';
+  return 'Play';
+}
+
+function muteVariant(muted: boolean): 'primary' | 'ghost' {
+  if (muted) return 'primary';
+  return 'ghost';
+}
+
+interface LooperTrackListProps {
+  looper: LooperApi;
+  /** drop the per-track transport and bar count, leaving level / mute / delete */
+  compact?: boolean;
+}
+
+/** One row per recorded or imported track: the control surface for the timeline. */
+export function LooperTrackList({ looper, compact = false }: LooperTrackListProps) {
+  // Track gains keyed by dynamic track id; default 1 for new tracks.
+  const [gains, setGains] = useState<Record<number, number>>({});
+
+  const setTrackGain = (id: number, value: number) => {
+    setGains((prev) => ({ ...prev, [id]: value }));
+    looper.setTrackGain(id, value);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {looper.tracks.map((trackRow) => {
+        const selected = trackRow.id === looper.selectedTrack;
+        const position = looper.tracks.indexOf(trackRow) + 1;
+        const recordingThis = looper.recordArmedTrack === trackRow.id;
+        const live = trackRow.state === 'playing' || trackRow.state === 'recording';
+        return (
+          <div
+            key={trackRow.id}
+            className={trackRowClass(selected)}
+            onClick={() => looper.selectTrack(trackRow.id)}
+          >
+            <Led active={live} />
+            <span
+              className="font-mono-display text-label text-text-secondary w-24 truncate"
+              title={trackRow.label}
+            >
+              {trackRow.label}
+            </span>
+            {!compact && (
+              <span
+                className="font-mono-display text-micro text-text-muted tabular-nums w-12"
+              >
+                {trackRow.bars > 0 && `${trackRow.bars}b`}
+                {trackRow.bars === 0 && '—'}
+              </span>
+            )}
+            {recordingThis && trackRow.state === 'armed' && (
+              <span className="font-mono-display text-caption text-accent-red">◌ armed</span>
+            )}
+            {recordingThis && trackRow.state !== 'armed' && (
+              <span className="font-mono-display text-caption text-accent-red">● recording</span>
+            )}
+            {!compact && (
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={!trackRow.hasAudio}
+                onClick={() => looper.togglePlay(trackRow.id)}
+              >
+                {playPauseLabel(trackRow.state)}
+              </Button>
+            )}
+            <Button
+              variant={muteVariant(trackRow.muted)}
+              size="sm"
+              disabled={!trackRow.hasAudio}
+              onClick={() => looper.setMute(trackRow.id, !trackRow.muted)}
+            >
+              Mute
+            </Button>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={gains[trackRow.id] ?? 1}
+              disabled={!trackRow.hasAudio}
+              onChange={(event) => setTrackGain(trackRow.id, Number(event.target.value))}
+              className="order-last basis-full sm:order-none sm:basis-0 sm:flex-1
+                min-w-0 accent-accent-amber"
+              aria-label={`Track ${position} level`}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="ml-auto sm:ml-0"
+              onClick={() => looper.clear(trackRow.id)}
+              title="Delete this track"
+            >
+              ✕
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/board/LooperPanel.tsx
+++ b/src/components/board/LooperPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/Button';
 import { Led } from '@/components/ui/Badge';
 import { LooperTimeline } from '@/components/board/LooperTimeline';
+import { LooperSetup, type LooperTempo } from '@/components/board/LooperSetup';
 import { track } from '@/core/analytics';
 import { fileExt } from '@/core/analyticsEvents';
 import type { LooperTriggerMap } from '@/core/looperTriggers';
@@ -20,6 +21,8 @@ const IMPORT_ACCEPT = 'audio/*,.wav,.mp3,.ogg,.flac,.m4a,.aac';
 
 interface LooperPanelProps {
   looper: LooperApi;
+  /** the practice drum machine's bar, offered as a grid to lock the loop to */
+  tempo: LooperTempo;
   bindings: LooperBindings;
   onBindingsChange: (next: LooperBindings) => void;
   /** enable the AUDIO IN capture: the looper needs the shared context running */
@@ -92,10 +95,32 @@ function assignStatusClass(armed: boolean, learned: boolean): string {
   return `${base} text-text-muted`;
 }
 
-function recordLabel(recording: boolean, armed: boolean): string {
+function recordLabel(recording: boolean, armed: boolean, listening: boolean): string {
+  if (listening) return '◌ LISTENING';
   if (armed) return '◌ ARMED';
   if (recording) return '■ STOP REC';
   return '● REC';
+}
+
+function recordTitle(listening: boolean): string {
+  if (listening) {
+    return 'Waiting for your first note , capture starts on the attack (Escape the wait with UNDO)';
+  }
+  return 'Record a new track / stop recording (R)';
+}
+
+/** One line of "what this take will do", so the setup drawer can stay shut. */
+function setupSummary(looper: LooperApi): string {
+  const parts: string[] = [];
+  if (looper.baseDurationSec === null) parts.push('bar not set');
+  else parts.push(`bar ${looper.baseDurationSec.toFixed(2)}s`);
+  if (looper.baseLocked) parts.push('locked to drums');
+  if (looper.settings.recordBars === null) parts.push('free length');
+  else parts.push(`${looper.settings.recordBars}-bar takes`);
+  if (looper.settings.autoStart) parts.push('starts on first note');
+  parts.push(`join ${looper.settings.tailBlendMs}ms`);
+  if (looper.settings.latencyTrimMs !== 0) parts.push(`trim ${looper.settings.latencyTrimMs}ms`);
+  return parts.join(' · ');
 }
 
 function recordVariant(active: boolean): 'danger' | 'secondary' {
@@ -133,6 +158,7 @@ function expValue(target: ExpTarget): string {
 
 export function LooperPanel({
   looper,
+  tempo,
   bindings,
   onBindingsChange,
   onEnableAudio,
@@ -150,6 +176,7 @@ export function LooperPanel({
   // Track gains keyed by dynamic track id; default 1 for new tracks.
   const [gains, setGains] = useState<Record<number, number>>({});
   const [importError, setImportError] = useState<string | null>(null);
+  const [setupOpen, setSetupOpen] = useState(!looper.hasContent);
   const { isRecording } = looper;
   const { active: audioActive, getLevels } = useAudioEngine();
 
@@ -215,6 +242,9 @@ export function LooperPanel({
   if (selectedPosition >= 0) {
     trackReadout = `${selectedPosition + 1}/${looper.tracks.length}`;
   }
+  // A take is "live" from the moment REC is pressed until it lands: waiting for
+  // the downbeat, waiting for the first note, or actually capturing.
+  const live = looper.isRecording || looper.isArmed || looper.isListening;
 
   return (
     <div className="flex flex-col gap-4">
@@ -237,14 +267,28 @@ export function LooperPanel({
             bottom of this drawer.
           </li>
           <li>
-            IMPORT loads a backing track and its length becomes one BAR , the
-            unit everything else is measured in. Record before importing and
-            your first take sets the bar instead.
+            <strong>Set the bar first.</strong> LOCK BAR TO DRUMS (in RECORD
+            SETUP) takes the practice drum machine's tempo, so the loop length is
+            exact. Otherwise the first thing in sets it , an imported file's own
+            length, or your first take, stop-press reaction time and all.
           </li>
           <li>
-            ● REC starts a NEW track; press again to stop. Once a bar exists,
-            recording waits for the downbeat (◌ ARMED) so takes always start in
-            time. Each take is rounded to the nearest whole number of bars.
+            ● REC starts a NEW track. With START ON FIRST NOTE on, the first take
+            waits for you to actually play and begins on the attack , the pick
+            itself is kept, not clipped. Once a loop is running, takes drop in on
+            the downbeat instead (◌ ARMED). Set a TAKE LENGTH in bars and the
+            recorder stops itself, sample-exact, with nothing to press in time.
+          </li>
+          <li>
+            The loop point is joined by mixing the ring-out captured PAST the end
+            back over the downbeat , the downbeat is never faded in. LOOP JOIN
+            sets how much: raise it if the wrap sounds cut off, lower it if the
+            last chord smears over the top of the loop.
+          </li>
+          <li>
+            If takes land consistently late or early, nudge TIMING TRIM. The app
+            already compensates for the round trip your interface reports; the
+            trim covers whatever that number misses.
           </li>
           <li>
             The loop is as long as the LONGEST take. Play past the end and it
@@ -255,6 +299,11 @@ export function LooperPanel({
             ▶ PLAY stops or restarts all tracks together. ◀ / ▶ move the
             selected track (highlighted row) , that's the track the EXP pedal's
             "Selected track level" controls.
+          </li>
+          <li>
+            <strong>Keys beat mice mid-phrase.</strong> R records, SPACE plays and
+            stops, and Ctrl+Z throws away the take in progress (or steps back
+            through finished ones). Full list in RECORD SETUP.
           </li>
           <li>
             Stomp assignments below: click ASSIGN STOMP on an action, then step
@@ -272,14 +321,24 @@ export function LooperPanel({
       <div className="flex flex-col gap-2">
         <div className="flex flex-wrap items-center gap-2">
           <Button
-            variant={recordVariant(looper.isRecording || looper.isArmed)}
+            variant={recordVariant(live)}
             size="sm"
             className="flex-1 sm:flex-none"
             onClick={looper.toggleRecord}
-            title="Record a new track / stop recording"
+            title={recordTitle(looper.isListening)}
           >
-            {recordLabel(looper.isRecording, looper.isArmed)}
+            {recordLabel(looper.isRecording, looper.isArmed, looper.isListening)}
           </Button>
+          {live && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={looper.cancelRecord}
+              title="Throw this take away and keep everything else (Ctrl+Z)"
+            >
+              ✕ CANCEL
+            </Button>
+          )}
           <Button
             variant="secondary"
             size="sm"
@@ -348,15 +407,34 @@ export function LooperPanel({
               ▶
             </Button>
           </div>
-          <Button
-            variant="danger"
-            size="sm"
-            className="ml-auto"
-            disabled={looper.tracks.length === 0}
-            onClick={looper.clearAll}
-          >
-            Clear All
-          </Button>
+          <div className="flex items-center gap-1 ml-auto">
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={!looper.canUndo && !live}
+              onClick={looper.undo}
+              title="Undo , cancels the take in progress, otherwise steps back one (Ctrl+Z)"
+            >
+              ↶ UNDO
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!looper.canRedo}
+              onClick={looper.redo}
+              title="Redo (Ctrl+Shift+Z)"
+            >
+              ↷
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              disabled={looper.tracks.length === 0}
+              onClick={looper.clearAll}
+            >
+              Clear All
+            </Button>
+          </div>
         </div>
         {/* The length model, stated plainly: bars, total, and one bar's worth */}
         <div className="flex items-center justify-between gap-2">
@@ -368,6 +446,34 @@ export function LooperPanel({
           </span>
         </div>
       </div>
+
+      {/* Capture settings: the four things that decide whether a loop lands in
+          time and wraps cleanly. Open by default until the first take exists,
+          because that is exactly when they matter and nobody goes looking for
+          a collapsed panel before their loop sounds wrong. */}
+      <details
+        className="rounded-lg border border-border-active bg-bg-deep/40"
+        open={setupOpen}
+        onToggle={(event) => setSetupOpen(event.currentTarget.open)}
+      >
+        <summary
+          className="px-3 py-2 cursor-pointer select-none list-none flex flex-wrap
+            items-baseline gap-x-3 gap-y-1"
+        >
+          <span
+            className="font-mono-display text-label text-text-secondary uppercase
+              tracking-widest"
+          >
+            ⚙ Record setup
+          </span>
+          <span className="font-mono-display text-caption text-text-muted">
+            {setupSummary(looper)}
+          </span>
+        </summary>
+        <div className="px-3 pb-3">
+          <LooperSetup looper={looper} tempo={tempo} />
+        </div>
+      </details>
 
       {importError && (
         <p

--- a/src/components/board/LooperPanel.tsx
+++ b/src/components/board/LooperPanel.tsx
@@ -1,23 +1,24 @@
-import { useEffect, useRef, useState } from 'react';
-import { useAudioEngine } from '@/components/AudioEngineProvider';
+import { useState } from 'react';
 import type { LooperApi } from '@/hooks/useLooper';
-import {
-  LOOPER_ACTION_KINDS,
-  type LooperBindings,
-  type LooperActionKind,
-  type ExpTarget,
-} from '@/core/looperBindings';
+import type { LooperBindings, LooperActionKind } from '@/core/looperBindings';
 import { Button } from '@/components/ui/Button';
-import { Led } from '@/components/ui/Badge';
-import { LooperTimeline } from '@/components/board/LooperTimeline';
-import { LooperSetup, type LooperTempo } from '@/components/board/LooperSetup';
-import { track } from '@/core/analytics';
-import { fileExt } from '@/core/analyticsEvents';
+import { LooperSimple } from '@/components/board/LooperSimple';
+import { LooperAdvanced } from '@/components/board/LooperAdvanced';
+import type { LooperTempo } from '@/components/board/LooperSetup';
+import { loadLooperMode, saveLooperMode, type LooperMode } from '@/core/looperMode';
 import type { LooperTriggerMap } from '@/core/looperTriggers';
 import type { LearnNotice } from '@/hooks/useLooperTriggers';
 
-/** Audio containers worth offering; the browser decodes whatever it supports. */
-const IMPORT_ACCEPT = 'audio/*,.wav,.mp3,.ogg,.flac,.m4a,.aac';
+// The loop station, in two faces.
+//
+// SIMPLE is one big context-labelled record button plus play / undo / import /
+// clear, a volume knob and the timeline , enough to record and stack loops
+// with nothing configured. ADVANCED adds the capture-edge settings, footswitch
+// learning and EXP routing on top of the same transport.
+//
+// The split is presentation only: both faces drive the same LooperApi, and any
+// shared control lives in LooperControls.tsx so the two cannot drift. The mode
+// is remembered per machine (core/looperMode.ts).
 
 interface LooperPanelProps {
   looper: LooperApi;
@@ -40,120 +41,39 @@ interface LooperPanelProps {
   learnEnabled: boolean;
 }
 
-const SELECT_CLASS =
-  'bg-bg-primary border border-border-active rounded px-2 py-1 ' +
-  'font-mono-display text-caption text-text-secondary';
-
-const ACTION_LABELS: Record<LooperActionKind, string> = {
-  recordToggle: 'Record / Stop',
-  playToggle: 'Play / Stop selected track',
-  muteToggle: 'Mute / Unmute selected track',
-  trackNext: 'Track +',
-  trackPrev: 'Track -',
-};
-
-function fmtLength(sec: number | null): string {
-  if (sec === null) return '- : -';
-  return `${sec.toFixed(2)}s`;
-}
-
-/** "4 BARS · 8.00s (2.00s/bar)" , the whole length model in one line. */
-function fmtCycle(bars: number, cycleSec: number | null, baseSec: number | null): string {
-  if (cycleSec === null || baseSec === null) return 'no loop yet';
-  const plural = bars === 1 ? '' : 'S';
-  return `${bars} BAR${plural} · ${fmtLength(cycleSec)} (${fmtLength(baseSec)}/bar)`;
-}
-
-function learnLabel(armed: boolean, learned: boolean): string {
-  if (armed) return '● STOMP NOW';
-  if (learned) return 'REASSIGN';
-  return 'ASSIGN STOMP';
-}
-
-function learnVariant(armed: boolean): 'danger' | 'secondary' {
-  if (armed) return 'danger';
-  return 'secondary';
-}
-
-function learnTitle(armed: boolean, learned: boolean, learnEnabled: boolean): string {
-  if (!learnEnabled) return 'Connect the GP-200 to assign a stomp';
-  if (armed) return 'Stomp any footswitch now (click to cancel)';
-  if (learned) return 'Assigned , click to assign a different switch';
-  return 'Click, then stomp any footswitch to assign it';
-}
-
-function assignStatus(armed: boolean, learned: boolean): string {
-  if (armed) return 'waiting for stomp…';
-  if (learned) return '✓ assigned';
-  return 'not assigned';
-}
-
-function assignStatusClass(armed: boolean, learned: boolean): string {
-  const base = 'font-mono-display text-caption';
-  if (armed) return `${base} text-accent-red`;
-  if (learned) return `${base} text-accent-amber`;
-  return `${base} text-text-muted`;
-}
-
-function recordLabel(recording: boolean, armed: boolean, listening: boolean): string {
-  if (listening) return '◌ LISTENING';
-  if (armed) return '◌ ARMED';
-  if (recording) return '■ STOP REC';
-  return '● REC';
-}
-
-function recordTitle(listening: boolean): string {
-  if (listening) {
-    return 'Waiting for your first note , capture starts on the attack (Escape the wait with UNDO)';
-  }
-  return 'Record a new track / stop recording (R)';
-}
-
-/** One line of "what this take will do", so the setup drawer can stay shut. */
-function setupSummary(looper: LooperApi): string {
-  const parts: string[] = [];
-  if (looper.baseDurationSec === null) parts.push('bar not set');
-  else parts.push(`bar ${looper.baseDurationSec.toFixed(2)}s`);
-  if (looper.baseLocked) parts.push('locked to drums');
-  if (looper.settings.recordBars === null) parts.push('free length');
-  else parts.push(`${looper.settings.recordBars}-bar takes`);
-  if (looper.settings.autoStart) parts.push('starts on first note');
-  parts.push(`join ${looper.settings.tailBlendMs}ms`);
-  if (looper.settings.latencyTrimMs !== 0) parts.push(`trim ${looper.settings.latencyTrimMs}ms`);
-  return parts.join(' · ');
-}
-
-function recordVariant(active: boolean): 'danger' | 'secondary' {
-  if (active) return 'danger';
-  return 'secondary';
-}
-
-function playAllLabel(anyPlaying: boolean): string {
-  if (anyPlaying) return '■ STOP';
-  return '▶ PLAY';
-}
-
-function trackRowClass(selected: boolean): string {
-  const base =
-    'flex flex-wrap items-center gap-2 px-3 py-2 rounded-lg border bg-bg-hover cursor-pointer';
-  if (selected) return `${base} border-accent-amber`;
-  return `${base} border-border-active`;
-}
-
-function playPauseLabel(state: string): string {
-  if (state === 'playing') return 'Pause';
-  return 'Play';
-}
-
-function muteVariant(muted: boolean): 'primary' | 'ghost' {
-  if (muted) return 'primary';
+function modeVariant(active: boolean): 'primary' | 'ghost' {
+  if (active) return 'primary';
   return 'ghost';
 }
 
-function expValue(target: ExpTarget): string {
-  if (target === null) return 'none';
-  if (target.kind === 'masterGain') return 'master';
-  return 'selected';
+interface ModeSwitchProps {
+  mode: LooperMode;
+  onChange: (next: LooperMode) => void;
+}
+
+function ModeSwitch({ mode, onChange }: ModeSwitchProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        size="sm"
+        variant={modeVariant(mode === 'simple')}
+        aria-pressed={mode === 'simple'}
+        onClick={() => onChange('simple')}
+        title="Just the controls you need to record and stack loops"
+      >
+        Simple
+      </Button>
+      <Button
+        size="sm"
+        variant={modeVariant(mode === 'advanced')}
+        aria-pressed={mode === 'advanced'}
+        onClick={() => onChange('advanced')}
+        title="Adds capture timing, take lengths, footswitch learning and EXP routing"
+      >
+        Advanced
+      </Button>
+    </div>
+  );
 }
 
 export function LooperPanel({
@@ -171,514 +91,67 @@ export function LooperPanel({
   learnNotice,
   learnEnabled,
 }: LooperPanelProps) {
-  const recBar = useRef<HTMLSpanElement>(null);
-  const fileInput = useRef<HTMLInputElement>(null);
-  // Track gains keyed by dynamic track id; default 1 for new tracks.
-  const [gains, setGains] = useState<Record<number, number>>({});
-  const [importError, setImportError] = useState<string | null>(null);
-  const [setupOpen, setSetupOpen] = useState(!looper.hasContent);
-  const { isRecording } = looper;
-  const { active: audioActive, getLevels } = useAudioEngine();
+  const [mode, setMode] = useState<LooperMode>(loadLooperMode);
 
-  // Live input level while actively recording, so silence doesn't go
-  // unnoticed , same rAF-driven read AudioMeters uses, gated to the
-  // recording pass only.
-  useEffect(() => {
-    if (!isRecording || !audioActive) return;
-    let raf = 0;
-    const tick = () => {
-      const { input } = getLevels();
-      if (recBar.current) recBar.current.style.width = `${(input * 100).toFixed(1)}%`;
-      raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [isRecording, audioActive, getLevels]);
-
-  const updateExpTarget = (target: ExpTarget) => {
-    onBindingsChange({ ...bindings, expTarget: target });
-  };
-
-  const setTrackGain = (id: number, value: number) => {
-    setGains((prev) => ({ ...prev, [id]: value }));
-    looper.setTrackGain(id, value);
-  };
-
-  const handleImportPick = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    // Reset immediately so re-picking the SAME file still fires a change event.
-    e.target.value = '';
-    if (!file) return;
-    setImportError(null);
-    const error = await looper.importAudioFile(file);
-    setImportError(error);
-    // Safe to instrument at the call site (unlike record): import has no
-    // footswitch binding, so this is the only path in. Extension only , the
-    // filename itself is user data and never leaves the browser.
-    track('looper_import_audio', { ok: error === null, ext: fileExt(file.name) });
+  const changeMode = (next: LooperMode) => {
+    setMode(next);
+    saveLooperMode(next);
   };
 
   if (!looper.ready) {
+    let enableLabel = 'ENABLE AUDIO IN';
+    if (audioStarting) enableLabel = 'ENABLING…';
     return (
       <div className="text-center py-6">
         <p className="font-mono-display text-caption text-text-muted mb-3">
-          The loop station records the GP-200's USB audio here in the browser
-          (separate from the pedal's built-in looper): import a backing track,
+          The loop station records the GP-200&apos;s USB audio here in the browser
+          (separate from the pedal&apos;s built-in looper): import a backing track,
           then record guitar takes over it. Every take becomes its own track,
           and the loop grows to fit the longest one. Enable audio capture to
           start.
         </p>
         <Button onClick={onEnableAudio} disabled={audioStarting}>
-          {audioStarting ? 'ENABLING…' : 'ENABLE AUDIO IN'}
+          {enableLabel}
         </Button>
       </div>
     );
   }
 
-  const selectedPosition = looper.tracks.findIndex(
-    (track) => track.id === looper.selectedTrack,
-  );
-  let trackReadout = '-/-';
-  if (selectedPosition >= 0) {
-    trackReadout = `${selectedPosition + 1}/${looper.tracks.length}`;
-  }
-  // A take is "live" from the moment REC is pressed until it lands: waiting for
-  // the downbeat, waiting for the first note, or actually capturing.
-  const live = looper.isRecording || looper.isArmed || looper.isListening;
-
   return (
-    <div className="flex flex-col gap-4">
-      {/* Collapsible primer on the dynamic-track workflow */}
-      <details className="group">
-        <summary
-          className="font-mono-display text-label text-text-muted uppercase
-            tracking-widest cursor-pointer select-none list-none"
-        >
-          <span className="group-open:hidden">▸ How the looper works</span>
-          <span className="hidden group-open:inline">▾ How the looper works</span>
-        </summary>
-        <ul
-          className="font-mono-display text-caption text-text-muted mt-2 pl-4
-            flex flex-col gap-1 list-disc"
-        >
-          <li>
-            Records the GP-200's USB audio here in the browser , separate from
-            the pedal's built-in looper, which is the collapsed section at the
-            bottom of this drawer.
-          </li>
-          <li>
-            <strong>Set the bar first.</strong> LOCK BAR TO DRUMS (in RECORD
-            SETUP) takes the practice drum machine's tempo, so the loop length is
-            exact. Otherwise the first thing in sets it , an imported file's own
-            length, or your first take, stop-press reaction time and all.
-          </li>
-          <li>
-            ● REC starts a NEW track. With START ON FIRST NOTE on, the first take
-            waits for you to actually play and begins on the attack , the pick
-            itself is kept, not clipped. Once a loop is running, takes drop in on
-            the downbeat instead (◌ ARMED). Set a TAKE LENGTH in bars and the
-            recorder stops itself, sample-exact, with nothing to press in time.
-          </li>
-          <li>
-            The loop point is joined by mixing the ring-out captured PAST the end
-            back over the downbeat , the downbeat is never faded in. LOOP JOIN
-            sets how much: raise it if the wrap sounds cut off, lower it if the
-            last chord smears over the top of the loop.
-          </li>
-          <li>
-            If takes land consistently late or early, nudge TIMING TRIM. The app
-            already compensates for the round trip your interface reports; the
-            trim covers whatever that number misses.
-          </li>
-          <li>
-            The loop is as long as the LONGEST take. Play past the end and it
-            grows another bar; shorter tracks simply repeat underneath , you can
-            see the repeats ghosted in the timeline.
-          </li>
-          <li>
-            ▶ PLAY stops or restarts all tracks together. ◀ / ▶ move the
-            selected track (highlighted row) , that's the track the EXP pedal's
-            "Selected track level" controls.
-          </li>
-          <li>
-            <strong>Keys beat mice mid-phrase.</strong> R records, SPACE plays and
-            stops, and Ctrl+Z throws away the take in progress (or steps back
-            through finished ones). Full list in RECORD SETUP.
-          </li>
-          <li>
-            Stomp assignments below: click ASSIGN STOMP on an action, then step
-            on any footswitch , that switch is remembered on this machine. Give
-            the looper switches that do nothing else on the pedal (CTRL / TAP set
-            to None); see the warning below for why.
-          </li>
-        </ul>
-      </details>
-
-      {/* Transport: the same four controls the footswitch bindings target.
-          REC/PLAY grow to fill narrow screens (primary touch targets); the
-          track selector and Clear All wrap onto their own line when tight;
-          the loop-progress bar always gets a full-width row of its own. */}
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant={recordVariant(live)}
-            size="sm"
-            className="flex-1 sm:flex-none"
-            onClick={looper.toggleRecord}
-            title={recordTitle(looper.isListening)}
-          >
-            {recordLabel(looper.isRecording, looper.isArmed, looper.isListening)}
-          </Button>
-          {live && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={looper.cancelRecord}
-              title="Throw this take away and keep everything else (Ctrl+Z)"
-            >
-              ✕ CANCEL
-            </Button>
-          )}
-          <Button
-            variant="secondary"
-            size="sm"
-            className="flex-1 sm:flex-none"
-            disabled={looper.importing}
-            onClick={() => fileInput.current?.click()}
-            title="Import an audio file as a looping track"
-          >
-            {looper.importing ? 'DECODING…' : '⭳ IMPORT'}
-          </Button>
-          <input
-            ref={fileInput}
-            type="file"
-            accept={IMPORT_ACCEPT}
-            className="hidden"
-            onChange={handleImportPick}
-          />
-          {looper.isRecording && (
-            <span
-              className="flex items-center gap-1.5 basis-full sm:basis-auto"
-              title="Live input level while recording"
-            >
-              <span className="font-mono-display text-caption text-accent-red">IN</span>
-              <span className="w-16 sm:w-20 h-3 rounded bg-bg-hover overflow-hidden">
-                <span
-                  ref={recBar}
-                  className="block h-full bg-accent-red"
-                  style={{ width: '0%' }}
-                />
-              </span>
-            </span>
-          )}
-          <Button
-            variant="secondary"
-            size="sm"
-            className="flex-1 sm:flex-none"
-            disabled={looper.tracks.length === 0}
-            onClick={looper.togglePlayAll}
-            title="Play all tracks / stop all tracks"
-          >
-            {playAllLabel(looper.anyPlaying)}
-          </Button>
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={looper.tracks.length === 0}
-              onClick={looper.selectPrevTrack}
-              title="Select previous track"
-            >
-              ◀
-            </Button>
-            <span
-              className="font-mono-display text-caption text-text-secondary tabular-nums
-                w-12 text-center"
-            >
-              {trackReadout}
-            </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={looper.tracks.length === 0}
-              onClick={looper.selectNextTrack}
-              title="Select next track"
-            >
-              ▶
-            </Button>
-          </div>
-          <div className="flex items-center gap-1 ml-auto">
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={!looper.canUndo && !live}
-              onClick={looper.undo}
-              title="Undo , cancels the take in progress, otherwise steps back one (Ctrl+Z)"
-            >
-              ↶ UNDO
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={!looper.canRedo}
-              onClick={looper.redo}
-              title="Redo (Ctrl+Shift+Z)"
-            >
-              ↷
-            </Button>
-            <Button
-              variant="danger"
-              size="sm"
-              disabled={looper.tracks.length === 0}
-              onClick={looper.clearAll}
-            >
-              Clear All
-            </Button>
-          </div>
-        </div>
-        {/* The length model, stated plainly: bars, total, and one bar's worth */}
-        <div className="flex items-center justify-between gap-2">
-          <span className="font-mono-display text-label text-text-muted uppercase tracking-widest">
-            LOOP
-          </span>
-          <span className="font-mono-display text-caption text-text-secondary tabular-nums">
-            {fmtCycle(looper.cycleBars, looper.cycleDurationSec, looper.baseDurationSec)}
-          </span>
-        </div>
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-end">
+        <ModeSwitch mode={mode} onChange={changeMode} />
       </div>
 
-      {/* Capture settings: the four things that decide whether a loop lands in
-          time and wraps cleanly. Open by default until the first take exists,
-          because that is exactly when they matter and nobody goes looking for
-          a collapsed panel before their loop sounds wrong. */}
-      <details
-        className="rounded-lg border border-border-active bg-bg-deep/40"
-        open={setupOpen}
-        onToggle={(event) => setSetupOpen(event.currentTarget.open)}
-      >
-        <summary
-          className="px-3 py-2 cursor-pointer select-none list-none flex flex-wrap
-            items-baseline gap-x-3 gap-y-1"
-        >
-          <span
-            className="font-mono-display text-label text-text-secondary uppercase
-              tracking-widest"
-          >
-            ⚙ Record setup
-          </span>
-          <span className="font-mono-display text-caption text-text-muted">
-            {setupSummary(looper)}
-          </span>
-        </summary>
-        <div className="px-3 pb-3">
-          <LooperSetup looper={looper} tempo={tempo} />
-        </div>
-      </details>
-
-      {importError && (
-        <p
-          className="font-mono-display text-caption text-accent-red px-3 py-2 rounded-lg
-            border border-accent-red bg-accent-red/10"
-        >
-          {importError}
-        </p>
+      {mode === 'simple' && (
+        <LooperSimple
+          looper={looper}
+          tempo={tempo}
+          triggers={triggers}
+          armedAction={armedAction}
+          onArmLearn={onArmLearn}
+          onClearTrigger={onClearTrigger}
+          onClearAll={onClearAll}
+          learnNotice={learnNotice}
+          learnEnabled={learnEnabled}
+        />
       )}
 
-      {/* The visual: waveform lanes across the cycle with a shared playhead */}
-      <LooperTimeline looper={looper} />
-
-      {/* Track rows: the control surface for what the timeline shows */}
-      <div className="flex flex-col gap-2">
-        {looper.tracks.map((track) => {
-          const selected = track.id === looper.selectedTrack;
-          const position = looper.tracks.indexOf(track) + 1;
-          const recordingThis = looper.recordArmedTrack === track.id;
-          return (
-            <div
-              key={track.id}
-              className={trackRowClass(selected)}
-              onClick={() => looper.selectTrack(track.id)}
-            >
-              <Led active={track.state === 'playing' || track.state === 'recording'} />
-              <span
-                className="font-mono-display text-label text-text-secondary w-24 truncate"
-                title={track.label}
-              >
-                {track.label}
-              </span>
-              <span className="font-mono-display text-micro text-text-muted tabular-nums w-12">
-                {track.bars > 0 ? `${track.bars}b` : '—'}
-              </span>
-              {recordingThis && (
-                <span className="font-mono-display text-caption text-accent-red">
-                  {track.state === 'armed' ? '◌ armed' : '● recording'}
-                </span>
-              )}
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={!track.hasAudio}
-                onClick={() => looper.togglePlay(track.id)}
-              >
-                {playPauseLabel(track.state)}
-              </Button>
-              <Button
-                variant={muteVariant(track.muted)}
-                size="sm"
-                disabled={!track.hasAudio}
-                onClick={() => looper.setMute(track.id, !track.muted)}
-              >
-                Mute
-              </Button>
-              <input
-                type="range"
-                min={0}
-                max={1}
-                step={0.01}
-                value={gains[track.id] ?? 1}
-                disabled={!track.hasAudio}
-                onChange={(e) => setTrackGain(track.id, Number(e.target.value))}
-                className="order-last basis-full sm:order-none sm:basis-0 sm:flex-1
-                  min-w-0 accent-accent-amber"
-                aria-label={`Track ${position} level`}
-              />
-              <Button
-                variant="ghost"
-                size="sm"
-                className="ml-auto sm:ml-0"
-                onClick={() => looper.clear(track.id)}
-                title="Delete this track"
-              >
-                ✕
-              </Button>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Stomp assignments: one row per transport action. The user never picks
-          a footswitch NUMBER , they arm an action and stomp whatever switch
-          they like, and the frame's fingerprint is cached for that action. */}
-      <div className="pt-2 border-t border-border-active">
-        <p className="font-mono-display text-label text-text-muted uppercase tracking-widest mb-1">
-          Stomp assignments
-        </p>
-        <p className="font-mono-display text-caption text-text-secondary mb-3">
-          Click ASSIGN STOMP, then step on any footswitch. While this dialog is
-          open a learned stomp drives the looper instead of your patch , the app
-          undoes the pedal&apos;s own reaction to it.
-        </p>
-        {/* Two constraints, both hard: (1) only CTRL 1-8 stomps produce a frame
-            this can fingerprint , a PATCH/BANK switch sends a slot change the
-            dispatcher must keep, and TAP/TUNER emit nothing learnable
-            (looperTriggers.ts, docs/protocol-capture.md §4); (2) the undo is a
-            single toggle-back (revertFor), so it can only cancel a switch that
-            flips ONE effect block , a CTRL assignment carrying a blockMask of
-            many blocks would leave the extras flipped. The app cannot read the
-            pedal's footswitch config, so this has to be a warning rather than a
-            check , and rewriting that config was tried twice and reverted,
-            because it is write-only and clobbers the user's real setup (see the
-            note in App.tsx). */}
-        <div
-          className="mb-3 px-3 py-2 rounded-lg border border-accent-amber
-            bg-accent-amber/10"
-        >
-          <p className="font-mono-display text-label text-accent-amber uppercase tracking-widest mb-1">
-            ⚠ Before you assign a footswitch
-          </p>
-          <p className="font-mono-display text-caption text-text-secondary">
-            On the GP-200, the switches you want the looper to own must be set
-            to a <strong>CTRL 1–8</strong> assignment , not PATCH, BANK, TAP or
-            TUNER. Only a CTRL stomp sends something this app can recognise; a
-            patch or bank switch changes the pedal&apos;s slot instead, and the
-            looper will never hear it.
-          </p>
-          <p className="font-mono-display text-caption text-text-secondary mt-2">
-            Give each of those CTRL switches <strong>one effect block only</strong>.
-            A CTRL that toggles several blocks at once cannot be fully undone:
-            the looper action will fire, but the extra pedals stay flipped. One
-            switch, one job.
-          </p>
-        </div>
-        <div className="flex flex-col gap-2">
-          {LOOPER_ACTION_KINDS.map((action) => {
-            const learned = triggers[action] !== undefined;
-            const armed = armedAction === action;
-            const showNotice = learnNotice !== null && learnNotice.action === action;
-            return (
-              <div key={action} className="flex flex-col gap-1">
-                <div
-                  className="flex flex-wrap items-center gap-2 px-3 py-2 rounded-lg
-                    border border-border-active bg-bg-hover"
-                >
-                  <span className="font-mono-display text-label text-text-secondary w-32">
-                    {ACTION_LABELS[action]}
-                  </span>
-                  <span className={assignStatusClass(armed, learned)}>
-                    {assignStatus(armed, learned)}
-                  </span>
-                  <Button
-                    variant={learnVariant(armed)}
-                    size="sm"
-                    className="ml-auto"
-                    disabled={!learnEnabled}
-                    onClick={() => onArmLearn(action)}
-                    title={learnTitle(armed, learned, learnEnabled)}
-                  >
-                    {learnLabel(armed, learned)}
-                  </Button>
-                  {learned && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onClearTrigger(action)}
-                      title="Forget the switch assigned to this action"
-                    >
-                      ✕
-                    </Button>
-                  )}
-                </div>
-                {showNotice && (
-                  <p className="font-mono-display text-caption text-accent-red px-3">
-                    That switch is already assigned to {ACTION_LABELS[learnNotice.duplicateOf]} —
-                    not saved
-                  </p>
-                )}
-              </div>
-            );
-          })}
-        </div>
-        <div className="flex justify-end mt-2">
-          <Button
-            variant="danger"
-            size="sm"
-            onClick={onClearAll}
-            title="Forget every assigned stomp"
-          >
-            CLEAR ASSIGNMENTS
-          </Button>
-        </div>
-        <div className="flex flex-wrap items-center gap-2 mt-3">
-          <span className="font-mono-display text-label text-text-secondary w-16">EXP →</span>
-          <select
-            value={expValue(bindings.expTarget)}
-            onChange={(e) => {
-              const v = e.target.value;
-              if (v === 'none') updateExpTarget(null);
-              else if (v === 'master') updateExpTarget({ kind: 'masterGain' });
-              else updateExpTarget({ kind: 'selectedTrackGain' });
-            }}
-            className={`flex-1 sm:flex-none min-w-0 ${SELECT_CLASS}`}
-          >
-            <option value="none">-</option>
-            <option value="master">Master level</option>
-            <option value="selected">Selected track level</option>
-          </select>
-          <span className="font-mono-display text-caption text-text-muted basis-full sm:basis-auto">
-            (EXP wire format pending capture)
-          </span>
-        </div>
-      </div>
+      {mode === 'advanced' && (
+        <LooperAdvanced
+          looper={looper}
+          tempo={tempo}
+          bindings={bindings}
+          onBindingsChange={onBindingsChange}
+          triggers={triggers}
+          armedAction={armedAction}
+          onArmLearn={onArmLearn}
+          onClearTrigger={onClearTrigger}
+          onClearAll={onClearAll}
+          learnNotice={learnNotice}
+          learnEnabled={learnEnabled}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/board/LooperSetup.tsx
+++ b/src/components/board/LooperSetup.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { useAudioEngine } from '@/components/AudioEngineProvider';
+import { Button } from '@/components/ui/Button';
+import type { LooperApi } from '@/hooks/useLooper';
+import { LOOPER_HOTKEYS } from '@/hooks/useLooperHotkeys';
+import {
+  LATENCY_TRIM_MIN_MS,
+  LATENCY_TRIM_MAX_MS,
+  TAIL_BLEND_MAX_MS,
+  TRIGGER_DB_MIN,
+  TRIGGER_DB_MAX,
+  RECORD_BAR_CHOICES,
+} from '@/core/loopCapture';
+
+// The loop station's capture settings: everything that decides WHERE a take
+// starts, where it ends and how its loop point is joined. Split out of
+// LooperPanel because it is a settings surface with its own explanations,
+// not part of the transport , and because the phone reuses it verbatim.
+//
+// Every block states the setting in plain language underneath it: these are the
+// four knobs a looper actually gets judged on, and none of them are guessable
+// from a number alone.
+
+/** The practice drum machine's current bar, offered as a grid to lock to. */
+export interface LooperTempo {
+  bpm: number;
+  /** seconds in one bar at that tempo and signature */
+  barSeconds: number;
+  /** e.g. "120 BPM · 4/4" */
+  label: string;
+}
+
+interface LooperSetupProps {
+  looper: LooperApi;
+  tempo: LooperTempo;
+}
+
+const BLOCK_CLASS =
+  'flex flex-col gap-2 px-3 py-2.5 rounded-lg border border-border-active bg-bg-hover';
+const TITLE_CLASS =
+  'font-mono-display text-label text-text-secondary uppercase tracking-widest';
+const HINT_CLASS = 'font-mono-display text-caption text-text-muted';
+const VALUE_CLASS = 'font-mono-display text-caption text-accent-amber tabular-nums';
+
+interface BlockProps {
+  title: string;
+  value: string;
+  children: ReactNode;
+  hint: string;
+}
+
+function SetupBlock({ title, value, children, hint }: BlockProps) {
+  return (
+    <div className={BLOCK_CLASS}>
+      <div className="flex items-baseline justify-between gap-2">
+        <span className={TITLE_CLASS}>{title}</span>
+        <span className={VALUE_CLASS}>{value}</span>
+      </div>
+      {children}
+      <p className={HINT_CLASS}>{hint}</p>
+    </div>
+  );
+}
+
+interface BarChoice {
+  id: string;
+  label: string;
+  bars: number | null;
+}
+
+const TAKE_LENGTHS: BarChoice[] = [
+  { id: 'free', label: 'FREE', bars: null },
+  ...RECORD_BAR_CHOICES.map((bars) => ({ id: `bars-${bars}`, label: String(bars), bars })),
+];
+
+function takeVariant(selected: boolean): 'primary' | 'secondary' {
+  if (selected) return 'primary';
+  return 'secondary';
+}
+
+function takeLengthValue(recordBars: number | null): string {
+  if (recordBars === null) return 'free';
+  if (recordBars === 1) return '1 bar';
+  return `${recordBars} bars`;
+}
+
+function triggerValue(autoStart: boolean, triggerDb: number): string {
+  if (autoStart) return `${triggerDb} dB`;
+  return 'off';
+}
+
+function triggerToggleLabel(autoStart: boolean): string {
+  if (autoStart) return '● ON';
+  return '○ OFF';
+}
+
+/**
+ * Live input level with the trigger point marked on the same scale.
+ *
+ * The meter is the only way to set a threshold honestly: it has to sit above
+ * the room/amp hiss and below the quietest note you intend to start on, and
+ * that is a property of this rig, not a number anyone can guess. Level is read
+ * inside rAF and written straight to the DOM, like every other meter here.
+ */
+function TriggerMeter({ triggerDb }: { triggerDb: number }) {
+  const fillRef = useRef<HTMLDivElement>(null);
+  const { active, getLevels } = useAudioEngine();
+
+  useEffect(() => {
+    if (!active) return;
+    let raf = 0;
+    const tick = () => {
+      const { input } = getLevels();
+      if (fillRef.current) fillRef.current.style.width = `${(input * 100).toFixed(1)}%`;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [active, getLevels]);
+
+  // Both the meter and the marker use the engine's −60 dBFS..0 → 0..1 mapping,
+  // so what you see under the marker is what will trigger.
+  const markerPercent = ((triggerDb + 60) / 60) * 100;
+  return (
+    <div className="relative h-3 rounded bg-bg-deep overflow-hidden">
+      <div ref={fillRef} className="h-full bg-accent-green/70" style={{ width: '0%' }} />
+      <div
+        className="absolute inset-y-0 w-0.5 bg-accent-red"
+        style={{ left: `${markerPercent.toFixed(1)}%` }}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+function signedMs(value: number): string {
+  if (value > 0) return `+${value} ms`;
+  return `${value} ms`;
+}
+
+export function LooperSetup({ looper, tempo }: LooperSetupProps) {
+  const { settings, updateSettings } = looper;
+
+  const barLabel = () => {
+    if (looper.baseDurationSec === null) return 'not set yet';
+    return `${looper.baseDurationSec.toFixed(3)} s`;
+  };
+
+  const gridHint = () => {
+    if (looper.hasContent) {
+      return 'The bar is set for this session. Clear every track to choose a new one.';
+    }
+    if (looper.baseLocked) {
+      return 'Takes are rounded to this bar exactly , no reaction time in the tempo.';
+    }
+    return 'Otherwise your first take sets the bar, including however late you hit stop.';
+  };
+
+  const startHint = () => {
+    if (looper.hasContent) {
+      return 'A loop is already running, so takes drop in on its downbeat. This applies again to the first take after Clear All.';
+    }
+    if (settings.autoStart) {
+      return 'The first take waits for you to play, and keeps the pick attack that started it. Later takes drop in on the downbeat.';
+    }
+    return 'Takes start the moment you press REC. Later takes still wait for the downbeat.';
+  };
+
+  const takeHint = () => {
+    if (settings.recordBars === null) {
+      return 'Free takes end when you press stop, so their length carries your reaction time. Pick a bar count to end them exactly.';
+    }
+    return `Recording stops itself after ${takeLengthValue(settings.recordBars)}, sample-exact. Nothing to press in time.`;
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <SetupBlock title="Loop grid" value={barLabel()} hint={gridHint()}>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant={takeVariant(looper.baseLocked)}
+              disabled={looper.hasContent}
+              onClick={() => looper.lockBaseSeconds(tempo.barSeconds)}
+              title="Use one drum-machine bar as the looper's bar"
+            >
+              ⟳ LOCK BAR TO DRUMS
+            </Button>
+            <span className="font-mono-display text-caption text-text-secondary tabular-nums">
+              {tempo.label} · {tempo.barSeconds.toFixed(3)} s
+            </span>
+            {looper.baseLocked && !looper.hasContent && (
+              <Button size="sm" variant="ghost" onClick={looper.unlockBase}>
+                UNLOCK
+              </Button>
+            )}
+          </div>
+        </SetupBlock>
+
+        <SetupBlock
+          title="Take length"
+          value={takeLengthValue(settings.recordBars)}
+          hint={takeHint()}
+        >
+          <div className="flex flex-wrap items-center gap-1">
+            {TAKE_LENGTHS.map((choice) => (
+              <Button
+                key={choice.id}
+                size="sm"
+                variant={takeVariant(settings.recordBars === choice.bars)}
+                onClick={() => updateSettings({ recordBars: choice.bars })}
+                title={`Record ${choice.label} bar(s)`}
+              >
+                {choice.label}
+              </Button>
+            ))}
+          </div>
+        </SetupBlock>
+
+        <SetupBlock
+          title="Start on first note"
+          value={triggerValue(settings.autoStart, settings.triggerDb)}
+          hint={startHint()}
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant={takeVariant(settings.autoStart)}
+              onClick={() => updateSettings({ autoStart: !settings.autoStart })}
+              role="switch"
+              aria-checked={settings.autoStart}
+            >
+              {triggerToggleLabel(settings.autoStart)}
+            </Button>
+            <div className="flex-1 min-w-[9rem] flex flex-col gap-1">
+              <TriggerMeter triggerDb={settings.triggerDb} />
+              <input
+                type="range"
+                min={TRIGGER_DB_MIN}
+                max={TRIGGER_DB_MAX}
+                step={1}
+                value={settings.triggerDb}
+                disabled={!settings.autoStart}
+                onChange={(event) => updateSettings({ triggerDb: Number(event.target.value) })}
+                className="w-full accent-accent-red"
+                aria-label="Trigger level in dBFS"
+              />
+            </div>
+          </div>
+        </SetupBlock>
+
+        <SetupBlock
+          title="Loop join"
+          value={`${settings.tailBlendMs} ms`}
+          hint="How much of the ring-out past the loop end is mixed back over the downbeat. The downbeat itself is never faded , raise this if the wrap sounds cut off, lower it if the last chord smears."
+        >
+          <input
+            type="range"
+            min={0}
+            max={TAIL_BLEND_MAX_MS}
+            step={10}
+            value={settings.tailBlendMs}
+            onChange={(event) => updateSettings({ tailBlendMs: Number(event.target.value) })}
+            className="w-full accent-accent-amber"
+            aria-label="Loop join length in milliseconds"
+          />
+        </SetupBlock>
+      </div>
+
+      <SetupBlock
+        title="Timing trim"
+        value={`device ${looper.latencyMs} ms · trim ${signedMs(settings.latencyTrimMs)}`}
+        hint="Your interface reports the first number and the app already compensates for it. If takes still land late, raise the trim; if they land early, lower it. One click ≈ 5 ms."
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="range"
+            min={LATENCY_TRIM_MIN_MS}
+            max={LATENCY_TRIM_MAX_MS}
+            step={5}
+            value={settings.latencyTrimMs}
+            onChange={(event) => updateSettings({ latencyTrimMs: Number(event.target.value) })}
+            className="flex-1 min-w-[10rem] accent-accent-amber"
+            aria-label="Extra latency trim in milliseconds"
+          />
+          <span className="font-mono-display text-caption text-text-secondary tabular-nums w-20 text-right">
+            {signedMs(settings.latencyTrimMs)}
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={settings.latencyTrimMs === 0}
+            onClick={() => updateSettings({ latencyTrimMs: 0 })}
+          >
+            RESET
+          </Button>
+        </div>
+      </SetupBlock>
+
+      <div className={BLOCK_CLASS}>
+        <span className={TITLE_CLASS}>Keyboard</span>
+        <div className="grid gap-x-4 gap-y-1 sm:grid-cols-2">
+          {LOOPER_HOTKEYS.map((hotkey) => (
+            <div key={hotkey.keys} className="flex items-baseline gap-2">
+              <kbd
+                className="font-mono-display text-micro text-text-secondary uppercase
+                  tracking-widest px-1.5 py-0.5 rounded border border-border-active
+                  bg-bg-deep shrink-0"
+              >
+                {hotkey.keys}
+              </kbd>
+              <span className={HINT_CLASS}>{hotkey.label}</span>
+            </div>
+          ))}
+        </div>
+        <p className={HINT_CLASS}>
+          Work anywhere in the app while capture is on , the drawer does not have to
+          be open. They stand down while you are typing in a field.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/board/LooperSimple.tsx
+++ b/src/components/board/LooperSimple.tsx
@@ -1,0 +1,219 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import type { LooperApi } from '@/hooks/useLooper';
+import type { LooperTempo } from '@/components/board/LooperSetup';
+import { LooperTimeline } from '@/components/board/LooperTimeline';
+import {
+  LooperImportButton,
+  LooperInputMeter,
+  LooperMasterLevel,
+  LooperTrackList,
+} from '@/components/board/LooperControls';
+import { LooperStomps } from '@/components/board/LooperStomps';
+import { fmtCycle, playAllLabel, recordButtonState } from '@/components/board/looperLabels';
+import type { LooperActionKind } from '@/core/looperBindings';
+import type { LooperTriggerMap } from '@/core/looperTriggers';
+import type { LearnNotice } from '@/hooks/useLooperTriggers';
+
+// The loop station's SIMPLE face: one big button that says what it will do,
+// four small ones for everything you touch mid-session, a volume knob, and the
+// picture. Nothing here has to be configured before it works.
+//
+// Footswitch assignments ARE here, compacted to one button per action
+// (LooperStomps): hands-free transport is not an advanced feature on a looper,
+// it is the only way to work one while both hands are on the guitar.
+//
+// What is deliberately NOT here: latency trim, loop-join length, trigger
+// threshold, fixed take lengths and EXP routing. Every one of those has a
+// default that is right for a first loop, and all of them are one click away
+// under ADVANCED. The thing that made the old panel hard was never any single
+// control , it was meeting twenty-five of them at once.
+
+interface LooperSimpleProps {
+  looper: LooperApi;
+  /** the practice drum machine's bar, offered as a one-tap grid to lock to */
+  tempo: LooperTempo;
+  /* MIDI-learn: assign a hardware stomp to each transport action */
+  triggers: LooperTriggerMap;
+  armedAction: LooperActionKind | null;
+  onArmLearn: (action: LooperActionKind) => void;
+  onClearTrigger: (action: LooperActionKind) => void;
+  /** forget every assigned stomp at once */
+  onClearAll: () => void;
+  learnNotice: LearnNotice | null;
+  /** learning needs a connected GP-200 */
+  learnEnabled: boolean;
+}
+
+function syncVariant(locked: boolean): 'primary' | 'secondary' {
+  if (locked) return 'primary';
+  return 'secondary';
+}
+
+function syncLabel(locked: boolean, tempo: LooperTempo): string {
+  if (locked) return `⟳ SYNCED · ${tempo.label}`;
+  return '⟳ SYNC TO DRUMS';
+}
+
+function syncTitle(locked: boolean): string {
+  if (locked) {
+    return 'The loop is locked to the drum machine. Click to let your first take set it instead';
+  }
+  return 'Take the bar length from the practice drum machine, so the loop lands exactly in time';
+}
+
+export function LooperSimple({
+  looper,
+  tempo,
+  triggers,
+  armedAction,
+  onArmLearn,
+  onClearTrigger,
+  onClearAll,
+  learnNotice,
+  learnEnabled,
+}: LooperSimpleProps) {
+  const [importError, setImportError] = useState<string | null>(null);
+  const button = recordButtonState(looper);
+  const noTracks = looper.tracks.length === 0;
+
+  const handleSync = () => {
+    if (looper.baseLocked) {
+      looper.unlockBase();
+      return;
+    }
+    looper.lockBaseSeconds(tempo.barSeconds);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* The one control. Its label is the next thing that will happen, and the
+          line under it is why , which is what lets the wait states (listening
+          for a note, waiting for a downbeat) stop being a mystery. */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-stretch gap-2">
+          <Button
+            variant={button.variant}
+            size="lg"
+            className="flex-1 py-5 text-lg tracking-widest"
+            onClick={looper.toggleRecord}
+          >
+            {button.label}
+          </Button>
+          {button.live && (
+            <Button
+              variant="ghost"
+              size="lg"
+              onClick={looper.cancelRecord}
+              title="Throw this take away and keep everything else (Ctrl+Z)"
+              aria-label="Cancel this take"
+            >
+              ✕
+            </Button>
+          )}
+        </div>
+        <p className="font-mono-display text-caption text-text-muted text-center">
+          {button.hint}
+        </p>
+      </div>
+
+      {looper.isRecording && <LooperInputMeter barClassName="flex-1" />}
+
+      {/* Everything else you reach for mid-session, at one size, in one row. */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={noTracks}
+          onClick={looper.togglePlayAll}
+          title="Play or stop every track together (Space)"
+        >
+          {playAllLabel(looper.anyPlaying)}
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={!looper.canUndo && !button.live}
+          onClick={looper.undo}
+          title="Cancels the take in progress, otherwise removes the last one (Ctrl+Z)"
+        >
+          ↶ UNDO
+        </Button>
+        <LooperImportButton looper={looper} onError={setImportError} className="w-full" />
+        <Button
+          variant="danger"
+          size="sm"
+          disabled={noTracks}
+          onClick={looper.clearAll}
+          title="Delete every track and start over"
+        >
+          CLEAR
+        </Button>
+      </div>
+
+      <LooperMasterLevel
+        level={looper.settings.masterLevel}
+        onChange={(level) => looper.updateSettings({ masterLevel: level })}
+      />
+
+      {importError && (
+        <p
+          className="font-mono-display text-caption text-accent-red px-3 py-2 rounded-lg
+            border border-accent-red bg-accent-red/10"
+        >
+          {importError}
+        </p>
+      )}
+
+      {/* The loop's length, plus the single setup decision worth surfacing here:
+          locking the bar to the drum machine is the only way to get a loop with
+          no stop-press reaction time in it, and it costs one tap. It disappears
+          once something is recorded, because by then the bar is fixed. */}
+      <div
+        className="flex flex-wrap items-center gap-x-3 gap-y-2 px-3 py-2 rounded-lg
+          border border-border-active"
+      >
+        <span
+          className="font-mono-display text-label text-text-secondary uppercase
+            tracking-widest"
+        >
+          Loop
+        </span>
+        <span className="font-mono-display text-caption text-text-secondary tabular-nums">
+          {fmtCycle(looper.cycleBars, looper.cycleDurationSec, looper.baseDurationSec)}
+        </span>
+        {!looper.hasContent && (
+          <Button
+            size="sm"
+            variant={syncVariant(looper.baseLocked)}
+            className="ml-auto"
+            onClick={handleSync}
+            title={syncTitle(looper.baseLocked)}
+          >
+            {syncLabel(looper.baseLocked, tempo)}
+          </Button>
+        )}
+      </div>
+
+      <LooperTimeline looper={looper} />
+      <LooperTrackList looper={looper} compact />
+
+      <div className="pt-2 border-t border-border-active">
+        <LooperStomps
+          triggers={triggers}
+          armedAction={armedAction}
+          onArmLearn={onArmLearn}
+          onClearTrigger={onClearTrigger}
+          onClearAll={onClearAll}
+          learnNotice={learnNotice}
+          learnEnabled={learnEnabled}
+        />
+      </div>
+
+      <p className="font-mono-display text-caption text-text-muted">
+        Keys: <strong>R</strong> record · <strong>Space</strong> play/stop ·{' '}
+        <strong>Ctrl+Z</strong> undo. They work with this drawer shut.
+      </p>
+    </div>
+  );
+}

--- a/src/components/board/LooperStomps.tsx
+++ b/src/components/board/LooperStomps.tsx
@@ -1,0 +1,206 @@
+import { Button } from '@/components/ui/Button';
+import { LOOPER_ACTION_KINDS, type LooperActionKind } from '@/core/looperBindings';
+import type { LooperTriggerMap } from '@/core/looperTriggers';
+import type { LearnNotice } from '@/hooks/useLooperTriggers';
+
+// Footswitch assignments as a row of buttons rather than a row per action.
+//
+// The user never picks a switch NUMBER: they arm an ACTION and stomp whatever
+// switch they like, and the frame's fingerprint is cached against that action.
+// So each action only ever has three states , unassigned, waiting, assigned ,
+// and a button carries all three in its own label and colour. Five stacked
+// rows spent a third of the drawer restating that, which is why the loop
+// station's simple face could not afford to show them at all; compacted like
+// this, both faces can.
+
+/** Short button faces. The full action name goes in the tooltip / aria-label. */
+const SHORT_LABELS: Record<LooperActionKind, string> = {
+  recordToggle: 'REC / STOP',
+  playToggle: 'PLAY',
+  muteToggle: 'MUTE',
+  trackNext: 'TRACK +',
+  trackPrev: 'TRACK −',
+};
+
+const FULL_LABELS: Record<LooperActionKind, string> = {
+  recordToggle: 'Record / Stop',
+  playToggle: 'Play / Stop selected track',
+  muteToggle: 'Mute / Unmute selected track',
+  trackNext: 'Track +',
+  trackPrev: 'Track -',
+};
+
+function stompVariant(armed: boolean, learned: boolean): 'danger' | 'primary' | 'secondary' {
+  if (armed) return 'danger';
+  if (learned) return 'primary';
+  return 'secondary';
+}
+
+function stompLabel(action: LooperActionKind, armed: boolean, learned: boolean): string {
+  if (armed) return '● STOMP NOW';
+  if (learned) return `✓ ${SHORT_LABELS[action]}`;
+  return SHORT_LABELS[action];
+}
+
+function stompTitle(action: LooperActionKind, armed: boolean, learned: boolean): string {
+  if (armed) return `${FULL_LABELS[action]} , stomp any footswitch now (click to cancel)`;
+  if (learned) return `${FULL_LABELS[action]} , assigned. Click to use a different switch`;
+  return `${FULL_LABELS[action]} , click, then stomp any footswitch to assign it`;
+}
+
+function stompAriaLabel(action: LooperActionKind, armed: boolean, learned: boolean): string {
+  if (armed) return `${FULL_LABELS[action]}: waiting for a stomp`;
+  if (learned) return `${FULL_LABELS[action]}: assigned, reassign`;
+  return `${FULL_LABELS[action]}: not assigned, assign a stomp`;
+}
+
+/** The two hard constraints, shared by both faces so they cannot drift apart. */
+function ConstraintText() {
+  return (
+    <>
+      <p className="font-mono-display text-caption text-text-secondary">
+        On the GP-200, the switches you want the looper to own must be set to a{' '}
+        <strong>CTRL 1–8</strong> assignment , not PATCH, BANK, TAP or TUNER. Only a
+        CTRL stomp sends something this app can recognise; a patch or bank switch
+        changes the pedal&apos;s slot instead, and the looper will never hear it.
+      </p>
+      <p className="font-mono-display text-caption text-text-secondary mt-2">
+        Give each of those CTRL switches <strong>one effect block only</strong>. A
+        CTRL that toggles several blocks at once cannot be fully undone: the looper
+        action will fire, but the extra pedals stay flipped. One switch, one job.
+      </p>
+    </>
+  );
+}
+
+interface LooperStompsProps {
+  triggers: LooperTriggerMap;
+  armedAction: LooperActionKind | null;
+  onArmLearn: (action: LooperActionKind) => void;
+  onClearTrigger: (action: LooperActionKind) => void;
+  /** forget every assigned stomp at once */
+  onClearAll: () => void;
+  learnNotice: LearnNotice | null;
+  /** learning needs a connected GP-200 */
+  learnEnabled: boolean;
+  /** spell the pedal-side constraints out in full instead of behind a summary */
+  verbose?: boolean;
+}
+
+export function LooperStomps({
+  triggers,
+  armedAction,
+  onArmLearn,
+  onClearTrigger,
+  onClearAll,
+  learnNotice,
+  learnEnabled,
+  verbose = false,
+}: LooperStompsProps) {
+  const anyLearned = LOOPER_ACTION_KINDS.some((action) => triggers[action] !== undefined);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <span
+          className="font-mono-display text-label text-text-secondary uppercase
+            tracking-widest"
+        >
+          Footswitches
+        </span>
+        {learnEnabled && (
+          <span className="font-mono-display text-caption text-text-muted">
+            Click one, then step on any switch to assign it
+          </span>
+        )}
+        {!learnEnabled && (
+          <span className="font-mono-display text-caption text-text-muted">
+            Connect the GP-200 to assign footswitches
+          </span>
+        )}
+        {anyLearned && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto"
+            onClick={onClearAll}
+            title="Forget every assigned stomp"
+          >
+            CLEAR ALL
+          </Button>
+        )}
+      </div>
+
+      {/* gap-x-3, not 2: the per-button clear badge overhangs the corner by
+          6px on each side, and a tighter gap makes two adjacent badges touch. */}
+      <div className="flex flex-wrap gap-x-3 gap-y-2">
+        {LOOPER_ACTION_KINDS.map((action) => {
+          const learned = triggers[action] !== undefined;
+          const armed = armedAction === action;
+          return (
+            <div key={action} className="relative">
+              <Button
+                variant={stompVariant(armed, learned)}
+                size="sm"
+                disabled={!learnEnabled}
+                onClick={() => onArmLearn(action)}
+                title={stompTitle(action, armed, learned)}
+                aria-label={stompAriaLabel(action, armed, learned)}
+              >
+                {stompLabel(action, armed, learned)}
+              </Button>
+              {/* A sibling, not a child: a button inside a button is invalid
+                  markup and the inner one never receives its own clicks. */}
+              {learned && !armed && (
+                <button
+                  type="button"
+                  onClick={() => onClearTrigger(action)}
+                  title={`Forget the switch assigned to ${FULL_LABELS[action]}`}
+                  aria-label={`Forget the switch assigned to ${FULL_LABELS[action]}`}
+                  className="ui-btn absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full
+                    border border-border-active bg-bg-primary text-text-muted
+                    hover:text-accent-red hover:border-accent-red font-mono-display
+                    text-micro leading-none flex items-center justify-center"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {learnNotice !== null && (
+        <p className="font-mono-display text-caption text-accent-red">
+          That switch is already assigned to {FULL_LABELS[learnNotice.duplicateOf]} — not saved
+        </p>
+      )}
+
+      {verbose && (
+        <div className="px-3 py-2 rounded-lg border border-accent-amber bg-accent-amber/10">
+          <p
+            className="font-mono-display text-label text-accent-amber uppercase
+              tracking-widest mb-1"
+          >
+            ⚠ Before you assign a footswitch
+          </p>
+          <ConstraintText />
+        </div>
+      )}
+
+      {!verbose && (
+        <details className="rounded-lg border border-accent-amber bg-accent-amber/10">
+          <summary
+            className="px-3 py-2 cursor-pointer select-none list-none font-mono-display
+              text-caption text-accent-amber"
+          >
+            ⚠ Switches must be set to CTRL 1–8, one effect block each — why
+          </summary>
+          <div className="px-3 pb-2">
+            <ConstraintText />
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/components/board/LooperTimeline.tsx
+++ b/src/components/board/LooperTimeline.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import type { LooperApi, LooperTrack } from '@/hooks/useLooper';
 
 // The loop station's visual: one waveform lane per track, laid out across the
@@ -129,6 +129,26 @@ function drawLanes(
   });
 }
 
+interface RecordStatusProps {
+  armed: boolean | undefined;
+  listening: boolean;
+  readoutRef: RefObject<HTMLSpanElement | null>;
+}
+
+/** What the red overlay says while a take is live. Three states, because
+ *  "nothing is happening yet" and "we are waiting for YOU" are different
+ *  things and the player has to be able to tell them apart at a glance. */
+function RecordStatus({ armed, listening, readoutRef }: RecordStatusProps) {
+  if (listening) return <span>◌ LISTENING , starts on your first note</span>;
+  if (armed) return <span>◌ ARMED , starts on the downbeat</span>;
+  return (
+    <>
+      <span>● REC</span>
+      <span ref={readoutRef} />
+    </>
+  );
+}
+
 export function LooperTimeline({ looper }: LooperTimelineProps) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -208,19 +228,29 @@ export function LooperTimeline({ looper }: LooperTimelineProps) {
       }
 
       const elapsed = api.getRecordElapsedSec();
+      const base = api.baseDurationSec;
+      const target = api.settings.recordBars;
       const fill = recFillRef.current;
       if (fill) {
-        const cycle = api.cycleDurationSec;
-        // Past one cycle the bar wraps and keeps filling: the loop is about to
-        // grow, and the readout beside it names the bar count it is heading for.
-        const fraction = cycle && cycle > 0 ? (elapsed % cycle) / cycle : 0;
+        // A fixed-length take fills against the length it will stop at; a free
+        // one fills against the cycle and wraps, because passing the end means
+        // the loop is about to grow by a bar.
+        let fraction = 0;
+        if (target !== null && base !== null && base > 0) {
+          fraction = Math.min(1, elapsed / (base * target));
+        } else if (api.cycleDurationSec !== null && api.cycleDurationSec > 0) {
+          fraction = (elapsed % api.cycleDurationSec) / api.cycleDurationSec;
+        }
         fill.style.width = `${(fraction * 100).toFixed(1)}%`;
       }
       const readout = readoutRef.current;
       if (readout) {
-        const base = api.baseDurationSec;
-        const bars = base && base > 0 ? Math.max(1, Math.round(elapsed / base)) : 1;
-        readout.textContent = `${elapsed.toFixed(1)}s · ${bars} bar${bars === 1 ? '' : 's'}`;
+        let bars = 1;
+        if (base !== null && base > 0) bars = Math.max(1, Math.round(elapsed / base));
+        let suffix = ` · ${bars} bar`;
+        if (bars !== 1) suffix += 's';
+        if (target !== null) suffix = ` · bar ${Math.min(bars, target)} of ${target}`;
+        readout.textContent = `${elapsed.toFixed(1)}s${suffix}`;
       }
       raf = requestAnimationFrame(tick);
     };
@@ -311,14 +341,11 @@ export function LooperTimeline({ looper }: LooperTimelineProps) {
                 className="absolute inset-y-0 left-2 flex items-center gap-2
                   font-mono-display text-micro text-accent-red tabular-nums"
               >
-                {recordingTrack?.state === 'armed' ? (
-                  <span>◌ ARMED , starts on the downbeat</span>
-                ) : (
-                  <>
-                    <span>● REC</span>
-                    <span ref={readoutRef} />
-                  </>
-                )}
+                <RecordStatus
+                  armed={recordingTrack?.state === 'armed'}
+                  listening={looper.isListening}
+                  readoutRef={readoutRef}
+                />
               </span>
             </div>
           )}

--- a/src/components/board/PedalBoard.tsx
+++ b/src/components/board/PedalBoard.tsx
@@ -9,6 +9,7 @@ import { FxLoopArrows } from '@/components/FxLoopArrows';
 import { ControllerPanel } from '@/components/ControllerPanel';
 import { FootswitchPanel } from '@/components/FootswitchPanel';
 import { LooperPanel } from './LooperPanel';
+import type { LooperTempo } from './LooperSetup';
 import { DrumsPanel } from './DrumsPanel';
 import { DeviceLooperPanel } from './DeviceLooperPanel';
 import { RemotePanel } from './RemotePanel';
@@ -94,6 +95,8 @@ export interface PedalBoardProps {
   onPanelOpen: (panel: PanelId) => void;
   /* loop station */
   looper: LooperApi;
+  /** the practice drum machine's bar, so the loop grid can be locked to it */
+  looperTempo: LooperTempo;
   looperBindings: LooperBindings;
   onLooperBindingsChange: (next: LooperBindings) => void;
   onEnableAudio: () => void;
@@ -176,6 +179,7 @@ export function PedalBoard({
   onOpenGuide,
   onPanelOpen,
   looper,
+  looperTempo,
   looperBindings,
   onLooperBindingsChange,
   onEnableAudio,
@@ -517,6 +521,7 @@ export function PedalBoard({
         </div>
         <LooperPanel
           looper={looper}
+          tempo={looperTempo}
           bindings={looperBindings}
           onBindingsChange={onLooperBindingsChange}
           onEnableAudio={onEnableAudio}

--- a/src/components/board/PedalKnob.tsx
+++ b/src/components/board/PedalKnob.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { KnobParam } from '@/core/effectParams';
 import { KNOB_STYLES, type BodySpec } from './boardPalette';
 import { clampSnap, formatValue } from './paramValue';
@@ -17,6 +17,21 @@ const START_ANGLE = -135;
 const SWEEP = 270;
 /** pixels of vertical drag for a full min→max sweep (mockup-tested) */
 const DRAG_RANGE_PX = 160;
+/** wheel notches (and arrow-key presses) for a full min→max sweep */
+const NOTCHES_PER_SWEEP = 50;
+/** Chrome's pixel delta for one mouse-wheel detent */
+const WHEEL_NOTCH_DELTA = 100;
+/** a violent flick shouldn't slam the param into its rail in one event */
+const MAX_NOTCHES_PER_EVENT = 4;
+const LINE_DELTA_PX = 16;
+const PAGE_DELTA_PX = 400;
+
+/** Wheel deltas in the event's own unit, normalised to pixels. */
+function wheelPixels(event: WheelEvent): number {
+  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) return event.deltaY * LINE_DELTA_PX;
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) return event.deltaY * PAGE_DELTA_PX;
+  return event.deltaY;
+}
 
 function polar(cx: number, cy: number, r: number, deg: number): [number, number] {
   const rad = ((deg - 90) * Math.PI) / 180;
@@ -25,13 +40,15 @@ function polar(cx: number, cy: number, r: number, deg: number): [number, number]
 
 
 /**
- * Skeuomorphic rotary knob: 270° sweep, vertical pointer drag, double-click
- * reset, arrow-key steps. The pointer position IS the value. No value arc.
+ * Skeuomorphic rotary knob: 270° sweep, vertical pointer drag, mouse wheel,
+ * double-click reset, arrow-key steps. The pointer position IS the value.
+ * No value arc.
  */
 export function PedalKnob({ param, value, onChange, knobStyle, ink, pedalName }: PedalKnobProps) {
   const style = KNOB_STYLES[knobStyle];
   const [dragging, setDragging] = useState(false);
   const dragStart = useRef({ y: 0, value: 0 });
+  const unitRef = useRef<HTMLDivElement>(null);
 
   const pct = param.max > param.min ? (value - param.min) / (param.max - param.min) : 0;
   const angle = START_ANGLE + SWEEP * pct;
@@ -44,10 +61,78 @@ export function PedalKnob({ param, value, onChange, knobStyle, ink, pedalName }:
     ticks.push(`M ${x0} ${y0} L ${x1} ${y1}`);
   }
 
-  const keyStep = (param.max - param.min) / 50;
+  // never below the param's own step, or clampSnap would round a nudge straight
+  // back to the current value and the knob would sit dead under the wheel.
+  const rawStep = (param.max - param.min) / NOTCHES_PER_SWEEP;
+  const keyStep = Math.max(rawStep, param.step);
+
+  const nudge = (notches: number) => {
+    const next = clampSnap(value + notches * keyStep, param);
+    if (next !== value) onChange(next);
+  };
+  // the wheel listener below is attached once, so it reads the live handler
+  // through a ref rather than closing over a stale `value`.
+  const nudgeRef = useRef(nudge);
+  useEffect(() => {
+    nudgeRef.current = nudge;
+  });
+
+  useEffect(() => {
+    const unit = unitRef.current;
+    if (!unit) return;
+    // Leftover sub-notch scroll. A trackpad emits many tiny deltas that would
+    // each round to zero on their own, so they bank here until they add up.
+    let carried = 0;
+    // On the whole unit, not the cap: the name and value are part of the same
+    // control, and a wheel that dies the moment the pointer drifts onto the
+    // label reads as broken. React also registers `onWheel` passively at the
+    // root container, so preventDefault() from a JSX handler is a no-op and the
+    // board scrolls behind the knob -- hence the native non-passive listener.
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const scrolled = -wheelPixels(event);
+      if (scrolled === 0) return;
+      // a reversal is a new gesture; banked delta from the old direction
+      // would otherwise have to be paid off before the knob turned back.
+      if (Math.sign(scrolled) !== Math.sign(carried)) carried = 0;
+      carried += scrolled;
+      const notches = Math.trunc(carried / WHEEL_NOTCH_DELTA);
+      if (notches === 0) return;
+      carried -= notches * WHEEL_NOTCH_DELTA;
+      const capped = Math.max(-MAX_NOTCHES_PER_EVENT, Math.min(MAX_NOTCHES_PER_EVENT, notches));
+      nudgeRef.current(capped);
+    };
+    unit.addEventListener('wheel', onWheel, { passive: false });
+    return () => unit.removeEventListener('wheel', onWheel);
+  }, []);
 
   return (
-    <div className={`knob${dragging ? ' dragging' : ''}`}>
+    // the pointer drag, the wheel and the double-click reset all live on the
+    // unit rather than the cap: name and value are part of the same control,
+    // and a gesture that dies when the pointer drifts 10px onto the label reads
+    // as broken. The cap keeps the slider role, focus and arrow keys -- the
+    // labels are static text and would only add duplicate a11y nodes.
+    <div
+      className={`knob${dragging ? ' dragging' : ''}`}
+      ref={unitRef}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        e.currentTarget.setPointerCapture(e.pointerId);
+        dragStart.current = { y: e.clientY, value };
+        setDragging(true);
+      }}
+      onPointerMove={(e) => {
+        if (!dragging) return;
+        const range = param.max - param.min;
+        const travel = dragStart.current.y - e.clientY;
+        const raw = dragStart.current.value + (travel * range) / DRAG_RANGE_PX;
+        const next = clampSnap(raw, param);
+        if (next !== value) onChange(next);
+      }}
+      onPointerUp={() => setDragging(false)}
+      onPointerCancel={() => setDragging(false)}
+      onDoubleClick={() => onChange(param.default)}
+    >
       <svg
         viewBox="0 0 100 100"
         role="slider"
@@ -57,33 +142,25 @@ export function PedalKnob({ param, value, onChange, knobStyle, ink, pedalName }:
         aria-valuemax={param.max}
         aria-valuenow={Number(value.toFixed(param.step < 1 ? 1 : 0))}
         aria-valuetext={formatValue(value, param)}
-        onPointerDown={(e) => {
-          e.preventDefault();
-          e.currentTarget.setPointerCapture(e.pointerId);
-          dragStart.current = { y: e.clientY, value };
-          setDragging(true);
-        }}
-        onPointerMove={(e) => {
-          if (!dragging) return;
-          const range = param.max - param.min;
-          const raw = dragStart.current.value + ((dragStart.current.y - e.clientY) * range) / DRAG_RANGE_PX;
-          const next = clampSnap(raw, param);
-          if (next !== value) onChange(next);
-        }}
-        onPointerUp={() => setDragging(false)}
-        onDoubleClick={() => onChange(param.default)}
         onKeyDown={(e) => {
           if (e.key === 'ArrowUp' || e.key === 'ArrowRight') {
             e.preventDefault();
-            onChange(clampSnap(value + keyStep, param));
+            nudge(1);
           } else if (e.key === 'ArrowDown' || e.key === 'ArrowLeft') {
             e.preventDefault();
-            onChange(clampSnap(value - keyStep, param));
+            nudge(-1);
           }
         }}
       >
-        {ticks.map((d, i) => (
-          <path key={i} d={d} stroke={ink} strokeOpacity={0.35} strokeWidth={2.5} strokeLinecap="round" />
+        {ticks.map((tick) => (
+          <path
+            key={tick}
+            d={tick}
+            stroke={ink}
+            strokeOpacity={0.35}
+            strokeWidth={2.5}
+            strokeLinecap="round"
+          />
         ))}
         <circle cx={50} cy={50} r={34} fill={style.cap1} />
         <circle cx={46} cy={44} r={30} fill={style.cap0} />

--- a/src/components/board/board.css
+++ b/src/components/board/board.css
@@ -658,7 +658,9 @@
   transform: translateX(-50%);
   width: 30px;
   height: 11px;
-  z-index: 3;
+  /* above the hovered knob's lift (z-index 3): the lift grows upward and would
+     otherwise paint over the drag affordance and swallow its pointer. */
+  z-index: 4;
   border-radius: 3px;
   /* two staggered rows of dots, tinted with the pedal ink */
   background-image: radial-gradient(
@@ -807,13 +809,62 @@
   gap: 1px;
   width: 48px;
   user-select: none;
+  /* the drag surface is the whole unit now, so it -- not just the cap -- has to
+     claim the gesture before the stage's scroll axis does. */
+  touch-action: none;
+  /* z-index target: lets a lifted knob draw over its neighbours in the row. */
+  position: relative;
+  /* the lift scales the whole unit, so the name and value grow with the cap.
+     Grow upward from the bottom edge: a centred origin pushes the value readout
+     down into the BYPASSED tag (`.p-off-tag`, top: 42%, z-index 6 -- above the
+     knob, which sits under the bypass scrim by design). Anchoring the bottom
+     pins the readout where it already is and sends the growth into the empty
+     space above the cap instead. */
+  transform-origin: 50% 100%;
+  transition: transform 0.15s ease-out;
+  /* on the unit, not the cap: the name and value take the wheel too, so they
+     get the cursor that advertises it. A plain dot, not a glyph -- the pointer
+     sits dead centre on the cap while the knob turns, so anything larger hides
+     what it is editing. `ns-resize` is the fallback where SVG cursors are
+     refused. */
+  cursor: url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2216%22 height=%2216%22 viewBox=%220 0 16 16%22%3E%3Ccircle cx=%228%22 cy=%228%22 r=%224%22 fill=%22%23fff%22 opacity=%22.95%22/%3E%3Ccircle cx=%228%22 cy=%228%22 r=%222.6%22 fill=%22%2312161a%22/%3E%3C/svg%3E") 8 8, ns-resize;
 }
 .board-view .knob svg {
   width: 44px;
   height: 44px;
-  cursor: ns-resize;
-  touch-action: none;
   display: block;
+  transition: filter 0.15s ease-out;
+}
+/* Hover/focus lift. `transform` only -- `.knob` is a fixed 48px item in a
+   flex-wrap grid sitting under useBoardFit's `zoom`, so animating width/height
+   or font-size would reflow the whole pedal face (and could re-fit the board).
+   Scaling the unit rather than the cap alone is also what keeps the name and
+   value legible: they ride the same transform, so they can never collide with
+   each other the way two independently scaled spans 1px apart would.
+   Guarded by `hover: hover` so a touchscreen laptop (which keeps the desktop
+   tree) can't leave a knob stuck big after a tap. */
+@media (hover: hover) {
+  .board-view .knob:hover {
+    transform: scale(1.2);
+    z-index: 3;
+  }
+  .board-view .knob:hover svg {
+    filter: drop-shadow(0 0 4px var(--knob-glow)) drop-shadow(0 0 11px var(--knob-glow-soft));
+  }
+  /* the resting label is ellipsised to the 48px column ("FEEDBA..."); the lift
+     is only worth anything if it also spells the name out. Safe to overflow
+     because the lifted knob is the one on top. */
+  .board-view .knob:hover .k-label {
+    overflow: visible;
+    max-width: none;
+  }
+}
+.board-view .knob:has(svg:focus-visible) {
+  transform: scale(1.2);
+  z-index: 3;
+}
+.board-view .knob svg:focus-visible {
+  filter: drop-shadow(0 0 4px var(--knob-glow)) drop-shadow(0 0 11px var(--knob-glow-soft));
 }
 .board-view .k-label {
   font-family: var(--font-jetbrains-mono), monospace;
@@ -906,8 +957,18 @@
 .board-view .controls.amp-panel .k-value {
   color: var(--panel-text);
 }
+/* after the hover rule on purpose: same specificity, so dragging wins and the
+   lift/glow/cursor hold even if the pointer leaves the knob mid-drag. */
+.board-view .knob.dragging {
+  transform: scale(1.2);
+  z-index: 3;
+}
+.board-view .knob.dragging {
+  cursor: grabbing;
+}
 .board-view .knob.dragging svg {
-  filter: brightness(1.15);
+  filter: brightness(1.15) drop-shadow(0 0 5px var(--knob-glow))
+    drop-shadow(0 0 13px var(--knob-glow-soft));
 }
 
 /* ── mini switch + combo ── */
@@ -2252,6 +2313,13 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  /* the global block in index.css only collapses the duration; drop the size
+     change itself so a hover can't jump the knob for motion-sensitive users. */
+  .board-view .knob:hover,
+  .board-view .knob:has(svg:focus-visible),
+  .board-view .knob.dragging {
+    transform: none;
+  }
   .effect-picker .ep-row,
   .effect-picker .ep-cat,
   .effect-picker .ep-close,

--- a/src/components/board/looperLabels.ts
+++ b/src/components/board/looperLabels.ts
@@ -1,0 +1,103 @@
+import type { LooperApi } from '@/hooks/useLooper';
+
+// Plain-language state readouts shared by the loop station's SIMPLE and
+// ADVANCED faces. They live outside both so the two can never end up
+// describing the same transport state in different words.
+
+export function fmtLength(sec: number | null): string {
+  if (sec === null) return '- : -';
+  return `${sec.toFixed(2)}s`;
+}
+
+/** "4 BARS · 8.00s (2.00s/bar)" , the whole length model in one line. */
+export function fmtCycle(
+  bars: number,
+  cycleSec: number | null,
+  baseSec: number | null,
+): string {
+  if (cycleSec === null || baseSec === null) return 'no loop yet';
+  let plural = 'S';
+  if (bars === 1) plural = '';
+  return `${bars} BAR${plural} · ${fmtLength(cycleSec)} (${fmtLength(baseSec)}/bar)`;
+}
+
+export function playAllLabel(anyPlaying: boolean): string {
+  if (anyPlaying) return '■ STOP';
+  return '▶ PLAY';
+}
+
+/**
+ * What the record button reads off the looper , deliberately narrower than the
+ * whole LooperApi, so the state machine states its own inputs.
+ */
+export type RecordButtonInput = Pick<
+  LooperApi,
+  'isListening' | 'isArmed' | 'isRecording' | 'hasContent' | 'settings'
+>;
+
+export interface RecordButtonState {
+  label: string;
+  /** one line under the button saying what pressing it will actually do */
+  hint: string;
+  variant: 'primary' | 'danger';
+  /** a take is live: waiting for a note, waiting for the downbeat, capturing */
+  live: boolean;
+}
+
+/**
+ * The record control as a single state machine.
+ *
+ * The looper's one genuinely confusing moment is the gap between pressing REC
+ * and hearing anything , the take may be listening for a note, waiting for a
+ * downbeat, or already running, and all three used to look the same. Labelling
+ * the button with what it does NEXT, and spelling the wait out underneath, is
+ * what lets the simple face get away with one button.
+ */
+export function recordButtonState(looper: RecordButtonInput): RecordButtonState {
+  if (looper.isListening) {
+    return {
+      label: '◌ LISTENING',
+      hint: 'Play a note — the take starts on your attack, pick and all.',
+      variant: 'danger',
+      live: true,
+    };
+  }
+  if (looper.isArmed) {
+    return {
+      label: '◌ ARMED',
+      hint: 'Recording drops in on the next downbeat. Play along.',
+      variant: 'danger',
+      live: true,
+    };
+  }
+  if (looper.isRecording) {
+    return {
+      label: '■ STOP',
+      hint: 'Press at the end of the phrase — that is where the loop wraps.',
+      variant: 'danger',
+      live: true,
+    };
+  }
+  if (looper.hasContent) {
+    return {
+      label: '● ADD A TAKE',
+      hint: 'Layers a new track over the loop, starting on the downbeat.',
+      variant: 'primary',
+      live: false,
+    };
+  }
+  if (looper.settings.autoStart) {
+    return {
+      label: '● RECORD',
+      hint: 'Press, then play — the take begins on your first note.',
+      variant: 'primary',
+      live: false,
+    };
+  }
+  return {
+    label: '● RECORD',
+    hint: 'Starts straight away, and this take sets the loop length.',
+    variant: 'primary',
+    live: false,
+  };
+}

--- a/src/components/mobile/MobileShell.tsx
+++ b/src/components/mobile/MobileShell.tsx
@@ -76,6 +76,7 @@ export default function MobileShell({
   onOpenGuide,
   onPanelOpen,
   looper,
+  looperTempo,
   looperBindings,
   onLooperBindingsChange,
   onEnableAudio,
@@ -211,6 +212,7 @@ export default function MobileShell({
             <h2 className="m-screen-title">LOOP STATION</h2>
             <LooperPanel
               looper={looper}
+              tempo={looperTempo}
               bindings={looperBindings}
               onBindingsChange={onLooperBindingsChange}
               onEnableAudio={onEnableAudio}

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, type ReactNode } from 'react';
 import { Card } from './Card';
+import { useDialogAnchor } from './useDialogAnchor';
 
 interface DialogProps {
   open: boolean;
@@ -25,9 +26,12 @@ interface DialogProps {
 
 /* Mobile-first placements: bottom sheets hug the screen edges below sm
  * (native-sheet feel, square bottom corners, safe-area padding for the iOS
- * home indicator); center dialogs cap their height and scroll internally. */
+ * home indicator); center dialogs cap their height and scroll internally.
+ * "center" aligns to the start on purpose: useDialogAnchor writes the
+ * centering offset as a margin so the panel can't re-center itself every time
+ * its content changes height. */
 const OVERLAY_PLACEMENT: Record<'center' | 'bottom' | 'right', string> = {
-  center: 'justify-center items-center p-3 sm:p-4',
+  center: 'justify-center items-start p-3 sm:p-4',
   bottom: 'justify-center items-end p-0 sm:p-4',
   right: 'justify-end items-stretch',
 };
@@ -59,7 +63,10 @@ export function Dialog({
   padding = 'p-4 sm:p-6',
 }: DialogProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
   const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  useDialogAnchor(open, placement, overlayRef, panelRef);
 
   useEffect(() => {
     if (!open) return;
@@ -115,6 +122,7 @@ export function Dialog({
 
   return (
     <div
+      ref={overlayRef}
       className={`fixed inset-0 z-50 bg-black/60 flex ${OVERLAY_PLACEMENT[placement]}`}
       onClick={closeOnOverlayClick ? onClose : undefined}
     >

--- a/src/components/ui/useDialogAnchor.ts
+++ b/src/components/ui/useDialogAnchor.ts
@@ -1,0 +1,122 @@
+import { useLayoutEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+type Placement = 'center' | 'bottom' | 'right';
+
+/** Height of the overlay's content box (its padding is the dialog's margin). */
+function contentBoxHeight(overlay: HTMLElement): number {
+  const style = getComputedStyle(overlay);
+  const padTop = parseFloat(style.paddingTop) || 0;
+  const padBottom = parseFloat(style.paddingBottom) || 0;
+  return Math.max(0, overlay.clientHeight - padTop - padBottom);
+}
+
+/** Height the panel wants, including its own borders (scrollHeight excludes them). */
+function desiredHeight(panel: HTMLElement): number {
+  const borderY = panel.offsetHeight - panel.clientHeight;
+  return panel.scrollHeight + borderY;
+}
+
+/** The panel's stylesheet max-height (max-h-[88dvh] & co), in px. */
+function styleCap(panel: HTMLElement): number {
+  const cap = parseFloat(getComputedStyle(panel).maxHeight);
+  if (Number.isNaN(cap)) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return cap;
+}
+
+/**
+ * Holds a dialog's visible edge still for as long as it stays open.
+ *
+ * Both placements used to move whenever their content height changed, so
+ * switching a tab (Patch Settings), filtering a list (Effect Picker) or adding
+ * a looper track slid the dialog under the pointer, taking the control the
+ * user had just clicked with it. A centered panel re-centered, shifting by half
+ * the delta; a bottom sheet is pinned by its bottom edge, so its header slid
+ * instead.
+ *
+ * The fix is the same rule for both: measure once on open, then only ever move
+ * *up*, and only far enough that taller content still fits on screen.
+ *
+ * - center: the panel is top-aligned and the centering offset is written as a
+ *   margin, so shrinking content leaves the top where it is.
+ * - bottom: the measured height becomes a floor, so shrinking content can no
+ *   longer pull the sheet's header down.
+ *
+ * A viewport resize drops both measurements and re-centers from scratch, as
+ * does closing and reopening the dialog.
+ */
+export function useDialogAnchor(
+  open: boolean,
+  placement: Placement,
+  overlayRef: RefObject<HTMLDivElement | null>,
+  panelRef: RefObject<HTMLDivElement | null>,
+): void {
+  const anchorRef = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || placement === 'right') {
+      return;
+    }
+    const overlay = overlayRef.current;
+    const panel = panelRef.current;
+    if (!overlay || !panel) {
+      return;
+    }
+    // Read before the first write, or we would measure our own inline value.
+    const cssCap = styleCap(panel);
+
+    function measureCentered(available: number, height: number) {
+      const frozen = anchorRef.current;
+      let offset = Math.max(0, Math.round((available - height) / 2));
+      if (frozen !== null) {
+        offset = Math.min(frozen, Math.max(0, available - height));
+      }
+      anchorRef.current = offset;
+      return offset;
+    }
+
+    function measure() {
+      if (!overlay || !panel) {
+        return;
+      }
+      const available = contentBoxHeight(overlay);
+      const cap = Math.min(cssCap, available);
+      const height = Math.min(desiredHeight(panel), cap);
+      if (placement === 'bottom') {
+        // Bottom sheets are pinned by the bottom edge: a floor is what keeps
+        // the header still. The floor can only grow, and the stylesheet's
+        // max-height still bounds how tall the sheet gets.
+        const floor = Math.max(anchorRef.current ?? 0, height);
+        anchorRef.current = floor;
+        panel.style.minHeight = `${floor}px`;
+        return;
+      }
+      const offset = measureCentered(available, height);
+      panel.style.marginTop = `${offset}px`;
+      panel.style.maxHeight = `${Math.min(cap, available - offset)}px`;
+    }
+
+    function remeasure() {
+      anchorRef.current = null;
+      measure();
+    }
+
+    measure();
+
+    // Content swaps (tabs, filters, async panels) resize the panel, not the window.
+    const observer = new ResizeObserver(measure);
+    observer.observe(panel);
+    window.addEventListener('resize', remeasure);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', remeasure);
+      anchorRef.current = null;
+      panel.style.marginTop = '';
+      panel.style.maxHeight = '';
+      panel.style.minHeight = '';
+    };
+  }, [open, placement, overlayRef, panelRef]);
+}

--- a/src/core/loopCapture.ts
+++ b/src/core/loopCapture.ts
@@ -1,0 +1,267 @@
+// Pure capture-edge maths for the loop station: where a take really starts,
+// how its loop point is joined, and how much of the round trip has to be
+// compensated. Framework-agnostic and side-effect free apart from the
+// localStorage envelope at the bottom (same pattern as looperTriggers.ts).
+//
+// ── Why a tail blend and not a crossfade ────────────────────────────────────
+//
+// The downbeat is nearly always the loudest transient in a take, so the classic
+// "fade the head in, fade the tail out" crossfade destroys exactly the part
+// that makes a loop feel tight: the pick attack arrives at 20% gain and the
+// loop sounds like it is breathing in. Hardware loopers do the opposite. The
+// head is left at FULL gain from sample 0, and the recorder keeps running PAST
+// the loop end so the decay that was still ringing when the loop wrapped can be
+// summed back over the downbeat , the chord rings across the join exactly as it
+// would if you had kept playing. blendTail() is that sum; nothing here ever
+// touches the level of the head.
+//
+// ── Why the start is not simply "when the button was pressed" ───────────────
+//
+// A sample reaching the recorder at context frame X was played by the guitarist
+// at X − inputLatency, and the click/loop they played along to was heard
+// outputLatency after it was scheduled. Capture therefore has to begin
+// roundTripSamples() AFTER the musical downbeat, and the sample that lands there
+// is the downbeat. Compensating at the start (rather than trimming the head
+// afterwards) keeps the take's length exactly what was played.
+
+/** Peak magnitude below which the input counts as silence for onset tracing. */
+export const SILENCE_FLOOR = 0.0025;
+
+export function dbToGain(db: number): number {
+  return Math.pow(10, db / 20);
+}
+
+export function gainToDb(gain: number): number {
+  if (gain <= 0) return -Infinity;
+  return 20 * Math.log10(gain);
+}
+
+function clampIndex(samples: Float32Array, index: number): number {
+  if (samples.length === 0) return 0;
+  return Math.max(0, Math.min(Math.round(index), samples.length - 1));
+}
+
+/**
+ * Sum `tail` into the head of `body` under a raised-cosine decay, in place.
+ *
+ * The window is 1 at the loop point and 0 at the end of the blend, with zero
+ * slope at BOTH ends, so neither the join nor the end of the blend steps. The
+ * body's own samples are never attenuated. Returns how many samples were
+ * blended, which is 0 when either side is empty.
+ */
+export function blendTail(body: Float32Array, tail: Float32Array): number {
+  const count = Math.min(body.length, tail.length);
+  if (count <= 0) return 0;
+  for (let index = 0; index < count; index++) {
+    const window = 0.5 * (1 + Math.cos((Math.PI * index) / count));
+    body[index] += tail[index] * window;
+  }
+  return count;
+}
+
+function crossesZero(samples: Float32Array, index: number): boolean {
+  const current = samples[index];
+  if (current === 0) return true;
+  const previous = samples[index - 1];
+  if (previous < 0 && current > 0) return true;
+  return previous > 0 && current < 0;
+}
+
+/**
+ * Nearest sample to `index` where the waveform crosses zero, searched outwards
+ * up to `maxSearch` samples in each direction. Falls back to the quietest
+ * sample in the window when the signal never crosses (a DC-ish or very low
+ * frequency passage), so the head still starts from as close to zero as the
+ * recording offers and cannot click.
+ */
+export function snapToZeroCrossing(
+  samples: Float32Array,
+  index: number,
+  maxSearch: number,
+): number {
+  if (samples.length === 0) return 0;
+  const start = clampIndex(samples, index);
+  const radius = Math.max(0, Math.floor(maxSearch));
+  let quietest = start;
+  let quietestMagnitude = Math.abs(samples[start]);
+  for (let offset = 1; offset <= radius; offset++) {
+    const after = start + offset;
+    if (after < samples.length) {
+      if (crossesZero(samples, after)) return after;
+      const magnitude = Math.abs(samples[after]);
+      if (magnitude < quietestMagnitude) {
+        quietest = after;
+        quietestMagnitude = magnitude;
+      }
+    }
+    const before = start - offset;
+    if (before > 0) {
+      if (crossesZero(samples, before)) return before;
+      const magnitude = Math.abs(samples[before]);
+      if (magnitude < quietestMagnitude) {
+        quietest = before;
+        quietestMagnitude = magnitude;
+      }
+    }
+  }
+  return quietest;
+}
+
+export interface OnsetOptions {
+  /** index the level detector fired at */
+  triggerIndex: number;
+  /** magnitude below which the signal counts as silence */
+  floor: number;
+  /** how far back the attack may be traced, in samples */
+  maxBackoff: number;
+  /** zero-crossing search radius, in samples */
+  snapRadius: number;
+}
+
+/**
+ * Refine a level-detector hit into the true start of the note.
+ *
+ * A threshold fires part-way up the attack, so cutting there clips the pick
+ * itself , the one thing a loop must not lose. This walks BACK over the ramp to
+ * where the signal last sat in the noise floor, then snaps to a zero crossing
+ * so the head starts silent without a fade.
+ */
+export function findOnset(samples: Float32Array, options: OnsetOptions): number {
+  if (samples.length === 0) return 0;
+  const trigger = clampIndex(samples, options.triggerIndex);
+  const limit = Math.max(0, trigger - Math.max(0, Math.floor(options.maxBackoff)));
+  let index = trigger;
+  while (index > limit && Math.abs(samples[index - 1]) > options.floor) index--;
+  return snapToZeroCrossing(samples, index, options.snapRadius);
+}
+
+export interface LatencyInputs {
+  /** AudioContext.outputLatency (or a baseLatency estimate) in seconds */
+  outputLatencySec: number;
+  /** the capture track's reported latency in seconds */
+  inputLatencySec: number;
+  /** user trim, positive means "the take is landing early, capture later" */
+  trimMs: number;
+  sampleRate: number;
+}
+
+/**
+ * Frames between a scheduled musical instant and the sample that carries it.
+ *
+ * Never negative: capture cannot begin before the recorder was armed, so a
+ * trim that would push the start earlier than the downbeat clamps to zero.
+ */
+export function roundTripSamples(inputs: LatencyInputs): number {
+  const seconds =
+    inputs.outputLatencySec + inputs.inputLatencySec + inputs.trimMs / 1000;
+  return Math.max(0, Math.round(seconds * inputs.sampleRate));
+}
+
+// ── Record settings ─────────────────────────────────────────────────────────
+
+export interface LoopRecordSettings {
+  /** extra round-trip compensation in ms, on top of what the device reports */
+  latencyTrimMs: number;
+  /** ms of ring-out past the loop point summed back over the downbeat */
+  tailBlendMs: number;
+  /** begin the first take on the first note played instead of on the button */
+  autoStart: boolean;
+  /** peak level in dBFS that counts as "a note was played" */
+  triggerDb: number;
+  /** fixed take length in bars, or null to record until stopped */
+  recordBars: number | null;
+}
+
+export const LATENCY_TRIM_MIN_MS = -150;
+export const LATENCY_TRIM_MAX_MS = 150;
+export const TAIL_BLEND_MAX_MS = 800;
+export const TRIGGER_DB_MIN = -60;
+export const TRIGGER_DB_MAX = -6;
+/** Take lengths the UI offers; null (free running) is added by the panel. */
+export const RECORD_BAR_CHOICES: readonly number[] = [1, 2, 4, 8, 16];
+
+export const DEFAULT_RECORD_SETTINGS: LoopRecordSettings = {
+  latencyTrimMs: 0,
+  // Long enough for a strummed chord to ring across the join, short enough that
+  // the previous bar's last note does not smear over the whole downbeat.
+  tailBlendMs: 220,
+  autoStart: true,
+  triggerDb: -34,
+  recordBars: null,
+};
+
+function clampNumber(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, value));
+}
+
+function clampBars(value: number | null): number | null {
+  if (value === null) return null;
+  if (!Number.isFinite(value)) return null;
+  const bars = Math.round(value);
+  if (bars < 1) return null;
+  return Math.min(64, bars);
+}
+
+/** Merge a partial update onto current settings, clamping every field. */
+export function clampRecordSettings(
+  current: LoopRecordSettings,
+  patch: Partial<LoopRecordSettings>,
+): LoopRecordSettings {
+  const merged = { ...current, ...patch };
+  return {
+    latencyTrimMs: Math.round(clampNumber(
+      merged.latencyTrimMs,
+      LATENCY_TRIM_MIN_MS,
+      LATENCY_TRIM_MAX_MS,
+      DEFAULT_RECORD_SETTINGS.latencyTrimMs,
+    )),
+    tailBlendMs: Math.round(clampNumber(
+      merged.tailBlendMs,
+      0,
+      TAIL_BLEND_MAX_MS,
+      DEFAULT_RECORD_SETTINGS.tailBlendMs,
+    )),
+    autoStart: merged.autoStart === true,
+    triggerDb: Math.round(clampNumber(
+      merged.triggerDb,
+      TRIGGER_DB_MIN,
+      TRIGGER_DB_MAX,
+      DEFAULT_RECORD_SETTINGS.triggerDb,
+    )),
+    recordBars: clampBars(merged.recordBars),
+  };
+}
+
+const SETTINGS_KEY = 'gp200-studio.looper.record';
+
+/** Read persisted record settings, falling back to the defaults field by field. */
+export function loadRecordSettings(): LoopRecordSettings {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(SETTINGS_KEY);
+  } catch {
+    return DEFAULT_RECORD_SETTINGS;
+  }
+  if (raw === null) return DEFAULT_RECORD_SETTINGS;
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return DEFAULT_RECORD_SETTINGS;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return DEFAULT_RECORD_SETTINGS;
+  return clampRecordSettings(
+    DEFAULT_RECORD_SETTINGS,
+    parsed as Partial<LoopRecordSettings>,
+  );
+}
+
+/** Persist record settings; best-effort, like every other store in the app. */
+export function saveRecordSettings(settings: LoopRecordSettings): void {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    // Private mode / quota exceeded / storage disabled.
+  }
+}

--- a/src/core/loopCapture.ts
+++ b/src/core/loopCapture.ts
@@ -157,6 +157,48 @@ export function roundTripSamples(inputs: LatencyInputs): number {
   return Math.max(0, Math.round(seconds * inputs.sampleRate));
 }
 
+// ── Output stage ────────────────────────────────────────────────────────────
+
+/** Level below which the safety clipper is bit-transparent (≈ −4.4 dBFS). */
+export const SOFT_CLIP_KNEE = 0.6;
+
+/**
+ * Lookup curve for a zero-latency soft clipper on the loop station's output.
+ *
+ * Tracks SUM. Four takes at unity peak at four times full scale, and the hard
+ * clip the browser applies on the way to the speakers is what turns a loud
+ * loop into a nasty one. This bends everything above the knee towards a
+ * ceiling instead, so stacking stays loud but never turns to fizz.
+ *
+ * Deliberately a WaveShaper and not a DynamicsCompressor: Chromium's
+ * compressor carries a lookahead pre-delay, and the entire capture design here
+ * rests on the output leg costing exactly what `ctx.outputLatency` reports
+ * (see roundTripSamples). A per-sample lookup adds nothing to that.
+ *
+ * Below the knee y = x exactly, and the first derivative is 1 on both sides of
+ * it, so the transition into the bend cannot be heard. A WaveShaper clamps
+ * out-of-range input to the curve's endpoints, which makes the value at x = 1
+ * a hard ceiling for any level at all.
+ */
+// The explicit ArrayBuffer arg matters: WaveShaperNode.curve rejects the
+// default Float32Array<ArrayBufferLike>, which could be shared memory.
+export function softClipCurve(length = 2048): Float32Array<ArrayBuffer> {
+  const curve = new Float32Array(length);
+  const range = 1 - SOFT_CLIP_KNEE;
+  for (let index = 0; index < length; index++) {
+    // The curve is sampled across the shaper's own −1..1 input span.
+    const input = (index / (length - 1)) * 2 - 1;
+    const magnitude = Math.abs(input);
+    if (magnitude <= SOFT_CLIP_KNEE) {
+      curve[index] = input;
+      continue;
+    }
+    const excess = (magnitude - SOFT_CLIP_KNEE) / range;
+    curve[index] = Math.sign(input) * (SOFT_CLIP_KNEE + range * Math.tanh(excess));
+  }
+  return curve;
+}
+
 // ── Record settings ─────────────────────────────────────────────────────────
 
 export interface LoopRecordSettings {
@@ -170,6 +212,17 @@ export interface LoopRecordSettings {
   triggerDb: number;
   /** fixed take length in bars, or null to record until stopped */
   recordBars: number | null;
+  /**
+   * Loop-station output level, 0..1, applied to the master gain node.
+   *
+   * The one field here that is not a capture edge. It lives with the record
+   * settings because this is the looper's persisted per-machine preference
+   * bag, and an output level has to survive a reload like the rest of them.
+   * The default sits below unity because tracks SUM: every take stacks its
+   * full level on the last, and a rig whose USB output already runs hot has
+   * no headroom left by the third one.
+   */
+  masterLevel: number;
 }
 
 export const LATENCY_TRIM_MIN_MS = -150;
@@ -188,6 +241,10 @@ export const DEFAULT_RECORD_SETTINGS: LoopRecordSettings = {
   autoStart: true,
   triggerDb: -34,
   recordBars: null,
+  // -6 dB: a starting volume, not a ceiling. Low enough that a first loop is
+  // never a shock next to the amp, and that a second and third take can land
+  // on top before the safety clipper above has to do anything at all.
+  masterLevel: 0.5,
 };
 
 function clampNumber(value: number, min: number, max: number, fallback: number): number {
@@ -230,6 +287,12 @@ export function clampRecordSettings(
       DEFAULT_RECORD_SETTINGS.triggerDb,
     )),
     recordBars: clampBars(merged.recordBars),
+    masterLevel: clampNumber(
+      merged.masterLevel,
+      0,
+      1,
+      DEFAULT_RECORD_SETTINGS.masterLevel,
+    ),
   };
 }
 

--- a/src/core/looperMode.ts
+++ b/src/core/looperMode.ts
@@ -1,0 +1,31 @@
+// Which of the loop station's two faces the user last had open.
+//
+// Persisted per machine like every other looper preference (loopCapture.ts,
+// looperTriggers.ts): the mode is a habit of whoever is standing in front of
+// the rig, not a property of a patch or a file. New users land on SIMPLE.
+
+export type LooperMode = 'simple' | 'advanced';
+
+export const DEFAULT_LOOPER_MODE: LooperMode = 'simple';
+
+const MODE_KEY = 'gp200-studio.looper.mode';
+
+export function loadLooperMode(): LooperMode {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(MODE_KEY);
+  } catch {
+    return DEFAULT_LOOPER_MODE;
+  }
+  if (raw === 'advanced') return 'advanced';
+  if (raw === 'simple') return 'simple';
+  return DEFAULT_LOOPER_MODE;
+}
+
+export function saveLooperMode(mode: LooperMode): void {
+  try {
+    localStorage.setItem(MODE_KEY, mode);
+  } catch {
+    // Private mode / quota exceeded / storage disabled.
+  }
+}

--- a/src/core/looperTransport.ts
+++ b/src/core/looperTransport.ts
@@ -103,3 +103,27 @@ export function playhead(now: number, transportStart: number, loopDuration: numb
   const phase = (elapsed % loopDuration) / loopDuration;
   return phase < 0 ? 0 : phase;
 }
+
+/**
+ * Seconds in one bar at `bpm` with `beatsPerBar` quarter-note beats.
+ *
+ * Used to LOCK the looper's bar to the practice drum machine's tempo, which is
+ * the only way to get an exactly-in-time loop: a free-running first take ends
+ * when a human presses stop, and that press carries their reaction time (a
+ * tenth of a second or so) straight into the master tempo, where every later
+ * take inherits it. Returns 0 for a non-positive tempo or bar length.
+ */
+export function barSecondsFromTempo(bpm: number, beatsPerBar: number): number {
+  if (bpm <= 0 || beatsPerBar <= 0) return 0;
+  return (60 / bpm) * beatsPerBar;
+}
+
+/**
+ * Context frame a scheduled time lands on, for handing a boundary to the
+ * recorder worklet. The worklet compares against `currentFrame`, whose clock is
+ * exactly `currentTime * sampleRate`, so this is the only conversion needed to
+ * make an edge sample-accurate instead of setTimeout-accurate.
+ */
+export function frameAtTime(time: number, sampleRate: number): number {
+  return Math.max(0, Math.round(time * sampleRate));
+}

--- a/src/hooks/useLooper.ts
+++ b/src/hooks/useLooper.ts
@@ -19,6 +19,7 @@ import {
   clampRecordSettings,
   loadRecordSettings,
   saveRecordSettings,
+  softClipCurve,
   SILENCE_FLOOR,
   type LoopRecordSettings,
 } from '@/core/loopCapture';
@@ -407,9 +408,16 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     recorder.connect(silent);
     silent.connect(ctx.destination);
 
+    // mix bus → safety clipper → speakers. The level is a persisted setting,
+    // so the freshly built node starts at whatever the user last left it on
+    // rather than at unity (see the masterLevel effect below for later moves).
     const master = ctx.createGain();
-    master.gain.value = 1;
-    master.connect(ctx.destination);
+    master.gain.value = settingsRef.current.masterLevel;
+    const clipper = ctx.createWaveShaper();
+    clipper.curve = softClipCurve();
+    clipper.oversample = 'none';
+    master.connect(clipper);
+    clipper.connect(ctx.destination);
 
     // What the browser knows about the INPUT leg. This one is a property of the
     // opened stream and does not move, so it is read once with the graph.
@@ -1169,11 +1177,26 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     if (!muted) nodes.gain.gain.setTargetAtTime(gain, ctx.currentTime, 0.01);
   }, []);
 
+  /**
+   * Live master level, deliberately NOT persisted , this is the EXP pedal's
+   * path. A pedal sweep is a performance gesture, and writing every frame of
+   * it back to localStorage would leave the slider wherever the foot stopped.
+   * The UI slider goes through updateSettings({ masterLevel }) instead.
+   */
   const setMasterGain = useCallback((gain: number) => {
     const master = masterGainRef.current;
     const ctx = graphCtxRef.current;
     if (master && ctx) master.gain.setTargetAtTime(gain, ctx.currentTime, 0.01);
   }, []);
+
+  // Apply the stored output level whenever the user moves it. A graph built
+  // after this point picks the same value up from settingsRef in ensureGraph.
+  useEffect(() => {
+    const master = masterGainRef.current;
+    const ctx = graphCtxRef.current;
+    if (!master || !ctx) return;
+    master.gain.setTargetAtTime(settings.masterLevel, ctx.currentTime, 0.02);
+  }, [settings.masterLevel]);
 
   const updateSettings = useCallback((patch: Partial<LoopRecordSettings>) => {
     setSettings((prev) => {

--- a/src/hooks/useLooper.ts
+++ b/src/hooks/useLooper.ts
@@ -6,9 +6,22 @@ import {
   barsForCapture,
   cycleBars as widestBars,
   samplesToSeconds,
+  secondsToSamples,
   nextBoundary,
+  frameAtTime,
   playhead,
 } from '@/core/looperTransport';
+import {
+  blendTail,
+  findOnset,
+  roundTripSamples,
+  dbToGain,
+  clampRecordSettings,
+  loadRecordSettings,
+  saveRecordSettings,
+  SILENCE_FLOOR,
+  type LoopRecordSettings,
+} from '@/core/loopCapture';
 import {
   computePeaks,
   peaksFromChannels,
@@ -25,15 +38,17 @@ const recorderWorkletUrl = new URL('../audio/looper-recorder.worklet.js', import
 // Multi-track loop station built on the shared audio engine (useAudioMeter via
 // AudioEngineProvider). It taps the same GP-200 input source node, records raw
 // PCM through an AudioWorklet, and plays each track back as a looping
-// AudioBufferSourceNode. Timing math lives in the pure `looperTransport` core;
-// waveform reduction in `waveformPeaks`. This hook is the Web Audio glue +
-// React state.
+// AudioBufferSourceNode. Timing math lives in the pure `looperTransport` core,
+// capture-edge maths in `loopCapture`, waveform reduction in `waveformPeaks`.
+// This hook is the Web Audio glue + React state.
 //
 // ── The length model (the part worth reading) ────────────────────────────────
 //
 //   BASE   one "bar". Set ONCE by the first thing that lands: an imported file
 //          takes its own length as the base, or , if you record before
-//          importing , the first free-running take does. Never changes after.
+//          importing , the first free-running take does. It can also be LOCKED
+//          up front from the practice drum machine's tempo, which is the only
+//          way to get a bar with no human reaction time baked into it.
 //   CYCLE  the loop you hear and see: base x cycleBars, where cycleBars is the
 //          LARGEST bar count across all tracks. Recording a take longer than the
 //          current cycle GROWS it; deleting the take that was holding it wide
@@ -45,10 +60,35 @@ const recorderWorkletUrl = new URL('../audio/looper-recorder.worklet.js', import
 // everything on a boundary; the copy is a memcpy of already-decoded PCM and only
 // happens when the cycle actually changes, which is rare.
 //
-// Recording is boundary-aligned once a base exists: REC ARMS the take and
-// capture begins on the next cycle downbeat, so content always starts at cycle
-// position 0 and the timeline can draw it truthfully. With no base yet there is
-// no grid to wait for, so the first take rolls immediately.
+// ── Where a take really begins and ends ──────────────────────────────────────
+//
+// Nothing about the capture edges is decided on the main thread. The recorder
+// worklet is handed a target FRAME (or a trigger level) and starts/stops there
+// itself, because a setTimeout is late by however long the UI is busy. Three
+// arming modes, in the order they are chosen:
+//
+//   LEVEL  nothing is recorded yet and "start on first note" is on: the worklet
+//          listens, keeps a rolling pre-roll, and fires on the attack. The
+//          pre-roll is what makes this usable , a bare threshold always clips
+//          the pick , and findOnset() then walks back to where the note left
+//          the noise floor and snaps to a zero crossing.
+//   GRID   audio exists, so capture begins on the next cycle downbeat and the
+//          take always lands on the grid.
+//   NOW    no grid worth waiting for: roll immediately.
+//
+// Every one of those start frames is pushed LATER by roundTripSamples(): the
+// sample that carries the downbeat arrives output+input latency after the
+// downbeat was scheduled. Compensating at the START (rather than trimming the
+// head afterwards and padding the end with silence) is what keeps a take's
+// length equal to what was played , and the STOP edge is pushed by the same
+// amount, so a hand-stopped take is exactly the gap between the two presses.
+// The output leg only counts when the player is following audio we scheduled
+// (see captureOffsetFrames); with nothing playing there is nothing to follow.
+//
+// The loop point is joined by summing the ring-out CAPTURED PAST the loop end
+// back over the downbeat (loopCapture.blendTail), never by fading the head in:
+// the downbeat is the loudest transient in most takes and fading it is exactly
+// what makes a loop sound like it is breathing.
 //
 // Tracks are DYNAMIC: every record->stop cycle appends a track, as does every
 // import. The four transport controls the hardware bindings target: toggleRecord,
@@ -81,10 +121,14 @@ export interface LooperApi {
   isRecording: boolean;
   /** true between hitting REC and the downbeat that starts capture */
   isArmed: boolean;
+  /** true while the recorder is waiting for the first note to be played */
+  isListening: boolean;
   /** id of the track currently being recorded/armed, or null */
   recordArmedTrack: number | null;
   /** length of one bar in seconds; null until the first track lands */
   baseDurationSec: number | null;
+  /** the bar length was locked to a tempo instead of taken from a take */
+  baseLocked: boolean;
   /** how many bars wide the loop currently is (1 when no tracks) */
   cycleBars: number;
   /** the full loop length in seconds; null until the first track lands */
@@ -92,6 +136,8 @@ export interface LooperApi {
   /** the track the UI highlights and Track +/- moves; null when no tracks */
   selectedTrack: number | null;
   anyPlaying: boolean;
+  /** at least one track holds finalised audio */
+  hasContent: boolean;
   /** 0..1 within the cycle; read inside rAF, not React state */
   getPlayhead: () => number;
   /** seconds captured so far in the take in progress (0 when not recording) */
@@ -102,6 +148,8 @@ export interface LooperApi {
   importAudioFile: (file: File) => Promise<string | null>;
   /** record a NEW track, or stop the recording in progress */
   toggleRecord: () => void;
+  /** abandon the take in progress, keeping everything already recorded */
+  cancelRecord: () => void;
   /** stop every playing track, or restart all recorded tracks together */
   togglePlayAll: () => void;
   /** Play/stop the selected track only (the footswitch-bound action). */
@@ -117,6 +165,19 @@ export interface LooperApi {
   clearAll: () => void;
   setTrackGain: (trackId: number, gain: number) => void;
   setMasterGain: (gain: number) => void;
+  /** capture/timing preferences; persisted across sessions */
+  settings: LoopRecordSettings;
+  updateSettings: (patch: Partial<LoopRecordSettings>) => void;
+  /** round trip the device itself reports, in ms (before the user trim) */
+  latencyMs: number;
+  /** fix the bar length to `seconds` before anything is recorded */
+  lockBaseSeconds: (seconds: number) => void;
+  /** release a locked bar length so the next take defines it again */
+  unlockBase: () => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
 }
 
 // Per-track live Web Audio nodes + captured buffer (kept in a ref, never state).
@@ -131,20 +192,47 @@ interface TrackNodes {
   bars: number;
 }
 
-/** Seconds of fade applied where a capture is trimmed, so the splice is silent. */
-const TRIM_FADE_SEC = 0.005;
-
-/**
- * Ramp the last `TRIM_FADE_SEC` of a trimmed capture down to zero, in place.
- * Rounding a take to the nearest bar can cut mid-waveform; without this the
- * loop point ticks audibly on every pass.
- */
-function fadeTail(samples: Float32Array, sampleRate: number): void {
-  const fade = Math.min(Math.round(TRIM_FADE_SEC * sampleRate), samples.length);
-  if (fade <= 1) return;
-  const start = samples.length - fade;
-  for (let i = 0; i < fade; i++) samples[start + i] *= 1 - i / fade;
+/** One track as an undo entry: the row plus the audio behind it. */
+interface TrackSnapshot {
+  row: LooperTrack;
+  content: AudioBuffer;
+  gainValue: number;
 }
+
+/** Everything an undo step has to put back. AudioBuffers are shared by
+ *  reference, so a snapshot costs a few objects, not a copy of the audio. */
+interface LooperSnapshot {
+  tracks: TrackSnapshot[];
+  baseSamples: number | null;
+  baseLocked: boolean;
+  transportStart: number;
+  takeCount: number;
+  nextTrackId: number;
+  selectedTrack: number | null;
+}
+
+/** The take currently being captured, as the worklet reports it. */
+interface PendingTake {
+  trackId: number;
+  /** true when the worklet is level-armed, so the head needs onset refinement */
+  level: boolean;
+  /** context frame the first posted sample sits on (set on 'started') */
+  startFrame: number;
+  /** frames posted before the level trigger (0 in frame mode) */
+  prerollFrames: number;
+  /** latency the start edge was pushed by; the stop edge uses the same */
+  offsetFrames: number;
+  started: boolean;
+}
+
+/** How many undo steps to keep. Snapshots are cheap; the audio is shared. */
+const HISTORY_LIMIT = 24;
+/** Pre-roll kept while level-armed, so the attack that fires it is recorded. */
+const PREROLL_SEC = 0.08;
+/** Zero-crossing search radius when placing a level-armed take's first sample. */
+const ONSET_SNAP_SEC = 0.002;
+/** Floor on how long the recorder keeps running past the loop end. */
+const MIN_TAIL_SEC = 0.06;
 
 /**
  * Repeat `content` until it fills exactly `cycleSamples`, truncating any partial
@@ -165,15 +253,34 @@ function tileToCycle(ctx: BaseAudioContext, content: AudioBuffer, cycleSamples: 
   return tiled;
 }
 
+/** Concatenate the posted capture chunks into one contiguous buffer. */
+function flattenChunks(chunks: Float32Array[]): Float32Array {
+  let total = 0;
+  for (const chunk of chunks) total += chunk.length;
+  const flat = new Float32Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    flat.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return flat;
+}
+
 export function useLooper(engine: AudioMeterApi): LooperApi {
   const [tracks, setTracks] = useState<LooperTrack[]>([]);
   const [isRecording, setIsRecording] = useState(false);
   const [isArmed, setIsArmed] = useState(false);
+  const [isListening, setIsListening] = useState(false);
   const [importing, setImporting] = useState(false);
   const [recordArmedTrack, setRecordArmedTrack] = useState<number | null>(null);
   const [baseDurationSec, setBaseDurationSec] = useState<number | null>(null);
+  const [baseLocked, setBaseLocked] = useState(false);
   const [cycleBars, setCycleBars] = useState(1);
   const [selectedTrack, setSelectedTrack] = useState<number | null>(null);
+  const [settings, setSettings] = useState<LoopRecordSettings>(loadRecordSettings);
+  const [latencyMs, setLatencyMs] = useState(0);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
 
   // Ref mirrors so transport callbacks registered once (MIDI dispatch) always
   // see current values.
@@ -181,6 +288,8 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
   tracksRef.current = tracks;
   const selectedTrackRef = useRef(selectedTrack);
   selectedTrackRef.current = selectedTrack;
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
 
   // Web Audio graph (rebuilt whenever the engine opens a fresh context).
   const graphCtxRef = useRef<AudioContext | null>(null);
@@ -192,17 +301,51 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
   // Recording accumulation + transport anchor.
   const recordChunksRef = useRef<Float32Array[]>([]);
   const recordingTrackRef = useRef<number | null>(null);
+  const pendingTakeRef = useRef<PendingTake | null>(null);
   const recordStartTimeRef = useRef(0);
-  const armTimerRef = useRef<number | null>(null);
   // The length model: one bar, and how many bars wide the cycle is.
   const baseSamplesRef = useRef<number | null>(null);
+  const baseLockedRef = useRef(false);
   const cycleBarsRef = useRef(1);
   const transportStartRef = useRef(0);
   const nextTrackIdRef = useRef(0);
   const takeCountRef = useRef(0);
+  // The capture stream's own latency, read once when the graph is built.
+  const inputLatencyRef = useRef(0);
+  // Undo/redo stacks of whole-state snapshots.
+  const undoRef = useRef<LooperSnapshot[]>([]);
+  const redoRef = useRef<LooperSnapshot[]>([]);
 
   const patchTrack = useCallback((id: number, next: Partial<LooperTrack>) => {
-    setTracks((prev) => prev.map((t) => (t.id === id ? { ...t, ...next } : t)));
+    setTracks((prev) => prev.map((row) => {
+      if (row.id !== id) return row;
+      return { ...row, ...next };
+    }));
+  }, []);
+
+  /** True once any track holds finalised audio (an armed row does not count). */
+  const anyTrackHasAudio = useCallback((): boolean => {
+    for (const nodes of trackNodesRef.current.values()) {
+      if (nodes.content) return true;
+    }
+    return false;
+  }, []);
+
+  /**
+   * The round trip as it stands right now, and the number the panel shows.
+   *
+   * `outputLatency` is read LIVE rather than cached: Chromium reports 0 (or a
+   * placeholder) until the context has actually rendered for a while, so a
+   * value cached when the graph was built can be wrong by 200 ms. Falls back to
+   * twice the buffer size where the driver never reports one.
+   */
+  const currentLatency = useCallback((): { inputSec: number; outputSec: number } => {
+    const ctx = graphCtxRef.current;
+    if (!ctx) return { inputSec: 0, outputSec: 0 };
+    const outputSec = ctx.outputLatency || ctx.baseLatency * 2;
+    const latency = { inputSec: inputLatencyRef.current, outputSec };
+    setLatencyMs(Math.round((latency.inputSec + latency.outputSec) * 1000));
+    return latency;
   }, []);
 
   /** Cycle length in seconds, straight off the refs (safe inside rAF). */
@@ -211,6 +354,15 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     if (!ctx || baseSamplesRef.current === null) return 0;
     return samplesToSeconds(baseSamplesRef.current * cycleBarsRef.current, ctx.sampleRate);
   }, []);
+
+  // Handlers the recorder worklet's port calls. Held in a ref because the port
+  // callback is installed once per AudioContext, and closing over the take
+  // callbacks directly would pin the first render's versions of them.
+  const takeHandlersRef = useRef({
+    onStarted: (_startFrame: number, _prerollFrames: number) => {},
+    onEnded: (_bodyFrames: number) => {},
+    onCancelled: () => {},
+  });
 
   // Build (or rebuild) the node graph for the engine's current context. Loads
   // the recorder worklet once per context and wires source → recorder (a silent
@@ -231,9 +383,22 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     const recorder = new AudioWorkletNode(ctx, 'looper-recorder');
     recorder.port.onmessage = (event: MessageEvent) => {
       const msg = event.data;
-      if (msg?.type === 'chunk' && recordingTrackRef.current !== null) {
-        recordChunksRef.current.push(msg.samples as Float32Array);
+      if (!msg) return;
+      if (msg.type === 'chunk') {
+        if (recordingTrackRef.current !== null) {
+          recordChunksRef.current.push(msg.samples as Float32Array);
+        }
+        return;
       }
+      if (msg.type === 'started') {
+        takeHandlersRef.current.onStarted(msg.startFrame as number, msg.prerollFrames as number);
+        return;
+      }
+      if (msg.type === 'ended') {
+        takeHandlersRef.current.onEnded(msg.bodyFrames as number);
+        return;
+      }
+      if (msg.type === 'cancelled') takeHandlersRef.current.onCancelled();
     };
     source.connect(recorder);
     // Keep the recorder in the render graph without making sound.
@@ -246,6 +411,13 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     master.gain.value = 1;
     master.connect(ctx.destination);
 
+    // What the browser knows about the INPUT leg. This one is a property of the
+    // opened stream and does not move, so it is read once with the graph.
+    const streamTrack = source.mediaStream.getAudioTracks()[0];
+    const streamSettings: MediaTrackSettings & { latency?: number } =
+      streamTrack?.getSettings() ?? {};
+    inputLatencyRef.current = streamSettings.latency ?? ctx.baseLatency;
+
     graphCtxRef.current = ctx;
     recorderRef.current = recorder;
     masterGainRef.current = master;
@@ -255,16 +427,16 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
   }, [engine]);
 
   /** Create the per-track gain chain for a newly added track. */
-  const createTrackNodes = useCallback((id: number): TrackNodes | null => {
+  const createTrackNodes = useCallback((id: number, gainValue = 1): TrackNodes | null => {
     const ctx = graphCtxRef.current;
     const master = masterGainRef.current;
     if (!ctx || !master) return null;
     const gain = ctx.createGain();
-    gain.gain.value = 1;
+    gain.gain.value = gainValue;
     gain.connect(master);
     const nodes: TrackNodes = {
       gain,
-      gainValue: 1,
+      gainValue,
       content: null,
       tiled: null,
       source: null,
@@ -381,64 +553,236 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
   const dropEmptyTrack = useCallback((trackId: number) => {
     trackNodesRef.current.get(trackId)?.gain.disconnect();
     trackNodesRef.current.delete(trackId);
-    setTracks((prev) => prev.filter((t) => t.id !== trackId));
+    setTracks((prev) => prev.filter((row) => row.id !== trackId));
     setSelectedTrack((prev) => {
       if (prev !== trackId) return prev;
-      const remaining = tracksRef.current.filter((t) => t.id !== trackId);
+      const remaining = tracksRef.current.filter((row) => row.id !== trackId);
       if (remaining.length === 0) return null;
       return remaining[remaining.length - 1].id;
     });
   }, []);
 
-  const stopRecord = useCallback(() => {
-    const ctx = graphCtxRef.current;
-    const recorder = recorderRef.current;
-    const trackId = recordingTrackRef.current;
-    if (!ctx || !recorder || trackId === null) return;
-    if (armTimerRef.current !== null) {
-      clearTimeout(armTimerRef.current);
-      armTimerRef.current = null;
+  // ── Undo / redo ────────────────────────────────────────────────────────────
+
+  /** Snapshot every track that holds audio. Rows still being armed or decoded
+   *  are deliberately skipped: they are transient, and an undo that restored an
+   *  empty lane would be restoring a UI artefact rather than a take. */
+  const captureSnapshot = useCallback((): LooperSnapshot => {
+    const snapshots: TrackSnapshot[] = [];
+    for (const row of tracksRef.current) {
+      const nodes = trackNodesRef.current.get(row.id);
+      if (!nodes?.content) continue;
+      snapshots.push({ row, content: nodes.content, gainValue: nodes.gainValue });
     }
-    recorder.port.postMessage({ type: 'stop' });
+    return {
+      tracks: snapshots,
+      baseSamples: baseSamplesRef.current,
+      baseLocked: baseLockedRef.current,
+      transportStart: transportStartRef.current,
+      takeCount: takeCountRef.current,
+      nextTrackId: nextTrackIdRef.current,
+      selectedTrack: selectedTrackRef.current,
+    };
+  }, []);
+
+  const syncHistoryFlags = useCallback(() => {
+    setCanUndo(undoRef.current.length > 0);
+    setCanRedo(redoRef.current.length > 0);
+  }, []);
+
+  /** Record the state BEFORE a destructive or additive change. */
+  const pushHistory = useCallback(() => {
+    undoRef.current.push(captureSnapshot());
+    if (undoRef.current.length > HISTORY_LIMIT) undoRef.current.shift();
+    redoRef.current = [];
+    syncHistoryFlags();
+  }, [captureSnapshot, syncHistoryFlags]);
+
+  /** Rebuild the whole track set from a snapshot and relaunch what was playing. */
+  const restoreSnapshot = useCallback((snapshot: LooperSnapshot) => {
+    const ctx = graphCtxRef.current;
+    if (!ctx) return;
+    for (const [id, nodes] of trackNodesRef.current) {
+      stopTrack(id);
+      nodes.gain.disconnect();
+    }
+    trackNodesRef.current = new Map();
+
+    baseSamplesRef.current = snapshot.baseSamples;
+    baseLockedRef.current = snapshot.baseLocked;
+    transportStartRef.current = snapshot.transportStart;
+    takeCountRef.current = snapshot.takeCount;
+    nextTrackIdRef.current = snapshot.nextTrackId;
+    setBaseLocked(snapshot.baseLocked);
+    let restoredBaseSec: number | null = null;
+    if (snapshot.baseSamples !== null) {
+      restoredBaseSec = samplesToSeconds(snapshot.baseSamples, ctx.sampleRate);
+    }
+    setBaseDurationSec(restoredBaseSec);
+
+    for (const entry of snapshot.tracks) {
+      const nodes = createTrackNodes(entry.row.id, entry.gainValue);
+      if (!nodes) continue;
+      nodes.content = entry.content;
+      nodes.bars = entry.row.bars;
+      if (entry.row.muted) nodes.gain.gain.value = 0;
+    }
+    setTracks(snapshot.tracks.map((entry) => entry.row));
+    setSelectedTrack(snapshot.selectedTrack);
+    cycleBarsRef.current = 0; // force applyCycle to re-tile everything
+    applyCycle();
+    // applyCycle re-anchors the transport when the cycle width moves, which is
+    // right for a live edit and wrong for an undo: the restored tracks have to
+    // land back on the phase they were recorded against.
+    transportStartRef.current = snapshot.transportStart;
+    for (const entry of snapshot.tracks) {
+      if (entry.row.state === 'playing') startTrackPlayback(entry.row.id);
+    }
+  }, [applyCycle, createTrackNodes, startTrackPlayback, stopTrack]);
+
+  // ── Recording ──────────────────────────────────────────────────────────────
+
+  /**
+   * Frames between an instant and the sample that carries it.
+   *
+   * `againstPlayback` is what decides whether the output leg counts. Dropping in
+   * on a downbeat, the player is following audio we scheduled, so the full round
+   * trip applies: they hear it one output latency late and their answer arrives
+   * one input latency after that. Starting a take with nothing playing, there is
+   * nothing to follow , only the input leg is real, and charging them for the
+   * output leg would cut the first instant off the take.
+   */
+  const captureOffsetFrames = useCallback((againstPlayback: boolean): number => {
+    const ctx = graphCtxRef.current;
+    if (!ctx) return 0;
+    const { inputSec, outputSec } = currentLatency();
+    let outputLatencySec = 0;
+    if (againstPlayback) outputLatencySec = outputSec;
+    return roundTripSamples({
+      outputLatencySec,
+      inputLatencySec: inputSec,
+      trimMs: settingsRef.current.latencyTrimMs,
+      sampleRate: ctx.sampleRate,
+    });
+  }, [currentLatency]);
+
+  /** Clear the recording UI state without touching the tracks. */
+  const clearRecordState = useCallback(() => {
     recordingTrackRef.current = null;
+    recordChunksRef.current = [];
+    recordStartTimeRef.current = 0;
     setIsRecording(false);
     setIsArmed(false);
+    setIsListening(false);
     setRecordArmedTrack(null);
+  }, []);
 
+  /** The worklet has begun capturing: note where, and switch the UI to REC. */
+  const onCaptureStarted = useCallback((startFrame: number, prerollFrames: number) => {
+    const ctx = graphCtxRef.current;
+    const pending = pendingTakeRef.current;
+    if (!ctx || !pending) return;
+    pending.startFrame = startFrame;
+    pending.prerollFrames = prerollFrames;
+    pending.started = true;
+    // Elapsed is capture progress, measured from the frame the body began on:
+    // that is the number the bar counter and the fixed-length stop agree with,
+    // so the readout reaches "bar 4 of 4" exactly as the take ends.
+    recordStartTimeRef.current = samplesToSeconds(startFrame, ctx.sampleRate);
+    setIsArmed(false);
+    setIsListening(false);
+    setIsRecording(true);
+    patchTrack(pending.trackId, { state: 'recording' });
+  }, [patchTrack]);
+
+  /**
+   * Turn the captured chunks into a track.
+   *
+   * `bodyFrames` is the loop itself; everything the worklet posted after it is
+   * ring-out. Quantising can also push the loop point back inside the body, in
+   * which case the trimmed overrun simply joins that ring-out , both are the
+   * same thing musically, and both get summed over the downbeat.
+   */
+  const finalizeTake = useCallback((bodyFrames: number) => {
+    const ctx = graphCtxRef.current;
+    const pending = pendingTakeRef.current;
+    pendingTakeRef.current = null;
     const chunks = recordChunksRef.current;
-    recordChunksRef.current = [];
-    const captured = chunks.reduce((n, c) => n + c.length, 0);
+    clearRecordState();
+    if (!ctx || !pending) return;
 
-    // Trim the input-latency head so tracks share a constant offset.
-    const calibration = Math.round(ctx.baseLatency * ctx.sampleRate);
-    const flat = new Float32Array(captured);
-    let offset = 0;
-    for (const c of chunks) { flat.set(c, offset); offset += c.length; }
-    const trimmed = flat.subarray(Math.min(calibration, Math.max(0, captured - 1)));
-
-    if (trimmed.length === 0) {
-      dropEmptyTrack(trackId);
+    const flat = flattenChunks(chunks);
+    let head = 0;
+    if (pending.level) {
+      head = findOnset(flat, {
+        triggerIndex: pending.prerollFrames,
+        floor: SILENCE_FLOOR,
+        maxBackoff: pending.prerollFrames,
+        snapRadius: Math.round(ONSET_SNAP_SEC * ctx.sampleRate),
+      });
+    }
+    const captured = Math.max(0, Math.min(bodyFrames, flat.length) - head);
+    if (captured === 0) {
+      dropEmptyTrack(pending.trackId);
       return;
     }
 
     // Round to whole bars against the base , or, with no base yet, become it.
-    const { bars, samples } = quantizeToBase(trimmed.length, baseSamplesRef.current ?? 0);
+    const { bars, samples } = quantizeToBase(captured, baseSamplesRef.current ?? 0);
+    const firstContent = !anyTrackHasAudio();
     if (baseSamplesRef.current === null) {
       baseSamplesRef.current = samples;
-      transportStartRef.current = ctx.currentTime;
       setBaseDurationSec(samplesToSeconds(samples, ctx.sampleRate));
     }
+    if (firstContent) {
+      // Anchor the transport to when this take was PLAYED: the scheduling clock
+      // runs one output latency ahead of what the player hears, so subtracting
+      // the round trip makes every later take line up with this one by ear.
+      const { inputSec, outputSec } = currentLatency();
+      transportStartRef.current =
+        samplesToSeconds(pending.startFrame + head, ctx.sampleRate) - inputSec - outputSec;
+    }
 
-    // Pad (short) or truncate (long) to the exact bar length, fading a cut so
-    // the loop point does not click.
     const content = ctx.createBuffer(1, samples, ctx.sampleRate);
     const fitted = new Float32Array(samples);
-    fitted.set(trimmed.subarray(0, Math.min(trimmed.length, samples)));
-    if (trimmed.length > samples) fadeTail(fitted, ctx.sampleRate);
+    const bodyEnd = Math.min(head + samples, flat.length);
+    fitted.set(flat.subarray(head, bodyEnd));
+    // The loop join. NOT a crossfade: the head keeps its attack at full gain and
+    // the ring-out decays over it, which is what a hardware looper does and what
+    // makes the downbeat stay punchy across the wrap.
+    const tailWanted = Math.round((settingsRef.current.tailBlendMs / 1000) * ctx.sampleRate);
+    const tailEnd = Math.min(bodyEnd + tailWanted, flat.length);
+    blendTail(fitted, flat.subarray(bodyEnd, tailEnd));
     content.copyToChannel(fitted, 0);
 
-    installTrackAudio(trackId, content, bars, computePeaks(fitted, bucketsForBars(bars)));
-  }, [dropEmptyTrack, installTrackAudio]);
+    // Snapshot here rather than at arm time: an import or a delete may have
+    // landed while the take was rolling, and undo has to step back over THIS
+    // take only. captureSnapshot skips content-less rows, so the take's own
+    // armed lane is not in it.
+    pushHistory();
+    installTrackAudio(pending.trackId, content, bars, computePeaks(fitted, bucketsForBars(bars)));
+  }, [
+    clearRecordState,
+    currentLatency,
+    dropEmptyTrack,
+    anyTrackHasAudio,
+    installTrackAudio,
+    pushHistory,
+  ]);
+
+  /** The worklet abandoned the take (cancel, or a stop while still waiting). */
+  const onTakeCancelled = useCallback(() => {
+    const pending = pendingTakeRef.current;
+    pendingTakeRef.current = null;
+    clearRecordState();
+    if (pending) dropEmptyTrack(pending.trackId);
+  }, [clearRecordState, dropEmptyTrack]);
+
+  takeHandlersRef.current = {
+    onStarted: onCaptureStarted,
+    onEnded: finalizeTake,
+    onCancelled: onTakeCancelled,
+  };
 
   const startRecordNewTrack = useCallback(() => {
     void (async () => {
@@ -469,29 +813,94 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
       ]);
       setSelectedTrack(trackId);
 
-      const begin = () => {
-        armTimerRef.current = null;
-        // A stop between arming and the downbeat cancels the take.
-        if (recordingTrackRef.current !== trackId) return;
-        recordStartTimeRef.current = ctx.currentTime;
-        setIsArmed(false);
-        setIsRecording(true);
-        patchTrack(trackId, { state: 'recording' });
-        recorder.port.postMessage({ type: 'start' });
+      const current = settingsRef.current;
+      const rate = ctx.sampleRate;
+      const base = baseSamplesRef.current;
+      const running = anyTrackHasAudio();
+      // A fixed take length needs a bar to count in; without one the take runs
+      // until it is stopped and defines the bar itself.
+      let bodyFrames = 0;
+      if (base !== null && current.recordBars !== null) bodyFrames = base * current.recordBars;
+      // Keep recording past the end for the join, plus one pre-roll's worth: a
+      // level-armed take shifts its head forward by up to that much when the
+      // onset is refined, and the loop's last samples come out of the tail.
+      const tailSec = Math.max(MIN_TAIL_SEC, current.tailBlendMs / 1000) + PREROLL_SEC;
+      const tailFrames = Math.round(tailSec * rate);
+      // Wait for the first note only while nothing is looping yet: once audio is
+      // running there is a downbeat to drop in on, which is always the better
+      // reference than "whenever the player happens to hit a string".
+      const level = current.autoStart && !running;
+      const onGrid = running && base !== null;
+      const offsetFrames = captureOffsetFrames(onGrid);
+      pendingTakeRef.current = {
+        trackId,
+        level,
+        startFrame: 0,
+        prerollFrames: 0,
+        offsetFrames,
+        started: false,
       };
 
-      // No base yet means no grid to wait for: roll immediately and let this
-      // take define the bar. Otherwise arm and drop in on the next downbeat.
-      const duration = cycleDuration();
-      if (baseSamplesRef.current === null || duration <= 0) {
-        begin();
+      if (level) {
+        recorder.port.postMessage({
+          type: 'arm',
+          mode: 'level',
+          threshold: dbToGain(current.triggerDb),
+          prerollFrames: Math.round(PREROLL_SEC * rate),
+          holdQuanta: 2,
+          bodyFrames,
+          tailFrames,
+        });
+        setIsListening(true);
         return;
       }
-      setIsArmed(true);
-      const at = nextBoundary(ctx.currentTime, transportStartRef.current, duration);
-      armTimerRef.current = window.setTimeout(begin, Math.max(0, (at - ctx.currentTime) * 1000));
+
+      let startTime = ctx.currentTime;
+      if (onGrid) {
+        startTime = nextBoundary(ctx.currentTime, transportStartRef.current, cycleDuration());
+        setIsArmed(true);
+      }
+      recorder.port.postMessage({
+        type: 'arm',
+        mode: 'frame',
+        startFrame: frameAtTime(startTime, rate) + offsetFrames,
+        bodyFrames,
+        tailFrames,
+      });
     })();
-  }, [createTrackNodes, cycleDuration, ensureGraph, patchTrack]);
+  }, [
+    captureOffsetFrames,
+    createTrackNodes,
+    cycleDuration,
+    ensureGraph,
+    anyTrackHasAudio,
+  ]);
+
+  /** Stop the take in progress and keep it (the worklet still owes us a tail). */
+  const stopRecord = useCallback(() => {
+    const ctx = graphCtxRef.current;
+    const recorder = recorderRef.current;
+    const pending = pendingTakeRef.current;
+    if (!ctx || !recorder || recordingTrackRef.current === null) return;
+    // The stop edge moves by exactly what the start edge moved by, so the take
+    // is as long as the gap between the two presses , not one latency short.
+    // Without this the compensation would quietly shorten every free take.
+    const stopFrame = frameAtTime(ctx.currentTime, ctx.sampleRate) + (pending?.offsetFrames ?? 0);
+    recorder.port.postMessage({ type: 'stop', stopFrame });
+    // The UI leaves REC immediately; finalizeTake lands a beat later, once the
+    // ring-out has been captured.
+    setIsRecording(false);
+    setIsArmed(false);
+    setIsListening(false);
+  }, []);
+
+  /** Abandon the take in progress; nothing is added and nothing is lost. */
+  const cancelRecord = useCallback(() => {
+    const recorder = recorderRef.current;
+    if (recordingTrackRef.current === null) return;
+    recorder?.port.postMessage({ type: 'cancel' });
+    onTakeCancelled();
+  }, [onTakeCancelled]);
 
   /** Record a new track, or stop (and keep) the recording in progress. */
   const toggleRecord = useCallback(() => {
@@ -530,6 +939,7 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
       const trackId = nextTrackIdRef.current;
       nextTrackIdRef.current += 1;
       if (!createTrackNodes(trackId)) return 'Could not create the track.';
+      pushHistory();
       setTracks((prev) => [
         ...prev,
         {
@@ -546,15 +956,17 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
       ]);
       setSelectedTrack(trackId);
 
-      const bars = baseSamplesRef.current === null
-        ? 1
-        : barsForCapture(decoded.length, baseSamplesRef.current);
+      let bars = 1;
+      if (baseSamplesRef.current !== null) {
+        bars = barsForCapture(decoded.length, baseSamplesRef.current);
+      }
+      const firstContent = !anyTrackHasAudio();
       if (baseSamplesRef.current === null) {
         // First thing in: the file's own length IS the bar, used verbatim.
         baseSamplesRef.current = decoded.length;
-        transportStartRef.current = ctx.currentTime;
         setBaseDurationSec(decoded.duration);
       }
+      if (firstContent) transportStartRef.current = ctx.currentTime;
       const samples = baseSamplesRef.current * bars;
 
       // Fit to whole bars. An exact fit (always true for the first import)
@@ -562,10 +974,17 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
       let content = decoded;
       if (decoded.length !== samples) {
         content = ctx.createBuffer(decoded.numberOfChannels, samples, ctx.sampleRate);
+        const tailWanted = Math.round(
+          (settingsRef.current.tailBlendMs / 1000) * ctx.sampleRate,
+        );
         for (let ch = 0; ch < decoded.numberOfChannels; ch++) {
+          const source = decoded.getChannelData(ch);
           const fitted = new Float32Array(samples);
-          fitted.set(decoded.getChannelData(ch).subarray(0, Math.min(decoded.length, samples)));
-          if (decoded.length > samples) fadeTail(fitted, ctx.sampleRate);
+          fitted.set(source.subarray(0, Math.min(decoded.length, samples)));
+          // Same join as a recorded take: whatever the file had past the loop
+          // point decays back over its head instead of being cut dead.
+          const tailEnd = Math.min(samples + tailWanted, decoded.length);
+          blendTail(fitted, source.subarray(Math.min(samples, decoded.length), tailEnd));
           content.copyToChannel(fitted, ch);
         }
       }
@@ -577,7 +996,7 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     } finally {
       setImporting(false);
     }
-  }, [createTrackNodes, ensureGraph, installTrackAudio]);
+  }, [createTrackNodes, ensureGraph, anyTrackHasAudio, installTrackAudio, pushHistory]);
 
   const togglePlay = useCallback((id: number) => {
     const nodes = trackNodesRef.current.get(id);
@@ -604,30 +1023,30 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
 
   /** Stop everything, or restart every recorded track phase-locked. */
   const togglePlayAll = useCallback(() => {
-    const playing = tracksRef.current.some((t) => t.state === 'playing');
+    const playing = tracksRef.current.some((row) => row.state === 'playing');
     if (playing) {
-      for (const track of tracksRef.current) {
-        if (track.state !== 'playing') continue;
-        stopTrack(track.id);
-        patchTrack(track.id, { state: 'stopped' });
+      for (const row of tracksRef.current) {
+        if (row.state !== 'playing') continue;
+        stopTrack(row.id);
+        patchTrack(row.id, { state: 'stopped' });
       }
       return;
     }
     const ctx = graphCtxRef.current;
     if (ctx) transportStartRef.current = ctx.currentTime; // fresh common anchor
-    for (const track of tracksRef.current) {
-      if (track.hasAudio) startTrackPlayback(track.id);
+    for (const row of tracksRef.current) {
+      if (row.hasAudio) startTrackPlayback(row.id);
     }
   }, [patchTrack, startTrackPlayback, stopTrack]);
 
   const selectTrack = useCallback((trackId: number) => {
-    if (tracksRef.current.some((t) => t.id === trackId)) setSelectedTrack(trackId);
+    if (tracksRef.current.some((row) => row.id === trackId)) setSelectedTrack(trackId);
   }, []);
 
   const stepSelection = useCallback((step: number) => {
     const list = tracksRef.current;
     if (list.length === 0) return;
-    const currentIndex = list.findIndex((t) => t.id === selectedTrackRef.current);
+    const currentIndex = list.findIndex((row) => row.id === selectedTrackRef.current);
     let nextIndex = currentIndex + step;
     if (currentIndex === -1) nextIndex = 0;
     // wrap around so a footswitch can cycle endlessly
@@ -655,41 +1074,36 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
   const toggleMuteSelected = useCallback(() => {
     const id = selectedTrackRef.current;
     if (id === null) return;
-    const track = tracksRef.current.find((t) => t.id === id);
-    if (!track) return;
-    setMute(id, !track.muted);
+    const row = tracksRef.current.find((candidate) => candidate.id === id);
+    if (!row) return;
+    setMute(id, !row.muted);
   }, [setMute]);
 
+  /** Drop the bar/transport once nothing is left , unless the bar was locked to
+   *  a tempo, which is a deliberate setting and survives an empty board. */
   const resetTransportIfEmpty = useCallback(() => {
-    for (const nodes of trackNodesRef.current.values()) {
-      if (nodes.content) return;
-    }
-    baseSamplesRef.current = null;
-    cycleBarsRef.current = 1;
-    transportStartRef.current = 0;
+    if (anyTrackHasAudio()) return;
     takeCountRef.current = 0;
-    setBaseDurationSec(null);
+    cycleBarsRef.current = 1;
     setCycleBars(1);
-  }, []);
+    if (baseLockedRef.current) return;
+    baseSamplesRef.current = null;
+    transportStartRef.current = 0;
+    setBaseDurationSec(null);
+  }, [anyTrackHasAudio]);
 
   /** Remove a track entirely (tracks are dynamic; clearing deletes the row). */
   const clear = useCallback((id: number) => {
+    if (recordingTrackRef.current === id) {
+      cancelRecord();
+      return;
+    }
+    pushHistory();
     stopTrack(id);
     const nodes = trackNodesRef.current.get(id);
     if (nodes) nodes.gain.disconnect();
     trackNodesRef.current.delete(id);
-    if (recordingTrackRef.current === id) {
-      recordingTrackRef.current = null;
-      if (armTimerRef.current !== null) {
-        clearTimeout(armTimerRef.current);
-        armTimerRef.current = null;
-      }
-      recorderRef.current?.port.postMessage({ type: 'stop' });
-      setIsRecording(false);
-      setIsArmed(false);
-      setRecordArmedTrack(null);
-    }
-    const remaining = tracksRef.current.filter((t) => t.id !== id);
+    const remaining = tracksRef.current.filter((row) => row.id !== id);
     setTracks(remaining);
     setSelectedTrack((prev) => {
       if (prev !== id) return prev;
@@ -699,37 +1113,59 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     // Deleting the widest track narrows the loop back down.
     applyCycle();
     resetTransportIfEmpty();
-  }, [applyCycle, resetTransportIfEmpty, stopTrack]);
+  }, [applyCycle, cancelRecord, pushHistory, resetTransportIfEmpty, stopTrack]);
 
   const clearAll = useCallback(() => {
-    for (const track of tracksRef.current) stopTrack(track.id);
+    if (tracksRef.current.length === 0) return;
+    pushHistory();
+    for (const row of tracksRef.current) stopTrack(row.id);
     for (const nodes of trackNodesRef.current.values()) nodes.gain.disconnect();
     trackNodesRef.current = new Map();
-    if (armTimerRef.current !== null) {
-      clearTimeout(armTimerRef.current);
-      armTimerRef.current = null;
-    }
-    recorderRef.current?.port.postMessage({ type: 'stop' });
-    recordingTrackRef.current = null;
-    baseSamplesRef.current = null;
-    cycleBarsRef.current = 1;
-    transportStartRef.current = 0;
+    recorderRef.current?.port.postMessage({ type: 'cancel' });
+    pendingTakeRef.current = null;
+    clearRecordState();
     takeCountRef.current = 0;
-    setIsRecording(false);
-    setIsArmed(false);
-    setRecordArmedTrack(null);
-    setBaseDurationSec(null);
+    cycleBarsRef.current = 1;
     setCycleBars(1);
     setTracks([]);
     setSelectedTrack(null);
-  }, [stopTrack]);
+    if (baseLockedRef.current) return;
+    baseSamplesRef.current = null;
+    transportStartRef.current = 0;
+    setBaseDurationSec(null);
+  }, [clearRecordState, pushHistory, stopTrack]);
+
+  /**
+   * Undo. While a take is in flight this cancels it instead of touching the
+   * history , that is what a player reaching for undo mid-take means, and it
+   * makes the shortcut safe to hit the instant a pass goes wrong.
+   */
+  const undo = useCallback(() => {
+    if (recordingTrackRef.current !== null) {
+      cancelRecord();
+      return;
+    }
+    const previous = undoRef.current.pop();
+    if (!previous) return;
+    redoRef.current.push(captureSnapshot());
+    restoreSnapshot(previous);
+    syncHistoryFlags();
+  }, [cancelRecord, captureSnapshot, restoreSnapshot, syncHistoryFlags]);
+
+  const redo = useCallback(() => {
+    const next = redoRef.current.pop();
+    if (!next) return;
+    undoRef.current.push(captureSnapshot());
+    restoreSnapshot(next);
+    syncHistoryFlags();
+  }, [captureSnapshot, restoreSnapshot, syncHistoryFlags]);
 
   const setTrackGain = useCallback((id: number, gain: number) => {
     const nodes = trackNodesRef.current.get(id);
     const ctx = graphCtxRef.current;
     if (!nodes || !ctx) return;
     nodes.gainValue = gain;
-    const muted = tracksRef.current.find((t) => t.id === id)?.muted ?? false;
+    const muted = tracksRef.current.find((row) => row.id === id)?.muted ?? false;
     if (!muted) nodes.gain.gain.setTargetAtTime(gain, ctx.currentTime, 0.01);
   }, []);
 
@@ -738,6 +1174,49 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     const ctx = graphCtxRef.current;
     if (master && ctx) master.gain.setTargetAtTime(gain, ctx.currentTime, 0.01);
   }, []);
+
+  const updateSettings = useCallback((patch: Partial<LoopRecordSettings>) => {
+    setSettings((prev) => {
+      const next = clampRecordSettings(prev, patch);
+      saveRecordSettings(next);
+      return next;
+    });
+  }, []);
+
+  /**
+   * Fix the bar length before anything is recorded , the tempo-sync path.
+   *
+   * A free-running first take ends when a human presses stop, so its length
+   * carries their reaction time and every later take inherits it. Locking the
+   * bar to a known tempo removes that error entirely, and combined with a fixed
+   * take length the recorder never has to guess where the loop ends.
+   */
+  const lockBaseSeconds = useCallback((seconds: number) => {
+    void (async () => {
+      const ok = await ensureGraph();
+      const ctx = graphCtxRef.current;
+      if (!ok || !ctx || seconds <= 0) return;
+      if (anyTrackHasAudio()) return;
+      const samples = secondsToSamples(seconds, ctx.sampleRate);
+      if (samples <= 0) return;
+      baseSamplesRef.current = samples;
+      baseLockedRef.current = true;
+      transportStartRef.current = ctx.currentTime;
+      cycleBarsRef.current = 1;
+      setBaseLocked(true);
+      setCycleBars(1);
+      setBaseDurationSec(samplesToSeconds(samples, ctx.sampleRate));
+    })();
+  }, [ensureGraph, anyTrackHasAudio]);
+
+  const unlockBase = useCallback(() => {
+    if (anyTrackHasAudio()) return;
+    baseLockedRef.current = false;
+    baseSamplesRef.current = null;
+    transportStartRef.current = 0;
+    setBaseLocked(false);
+    setBaseDurationSec(null);
+  }, [anyTrackHasAudio]);
 
   const getPlayhead = useCallback(() => {
     const ctx = graphCtxRef.current;
@@ -751,57 +1230,75 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     return Math.max(0, ctx.currentTime - recordStartTimeRef.current);
   }, []);
 
+  // Build the graph as soon as capture is on rather than on the first REC. Two
+  // reasons: the worklet module is fetched up front, so the first take is not
+  // delayed by a network round trip, and the device's reported latency is read
+  // in the same pass , which is what the setup panel shows and compensates for.
+  const ensureGraphRef = useRef(ensureGraph);
+  ensureGraphRef.current = ensureGraph;
+  useEffect(() => {
+    if (!engine.active) return;
+    void ensureGraphRef.current().then(() => currentLatency());
+  }, [currentLatency, engine.active]);
+
   // Tear down the graph and reset when the audio engine goes inactive (the
   // context is closed by useAudioMeter.disable, invalidating every node).
   useEffect(() => {
     if (engine.active) return;
-    if (armTimerRef.current !== null) {
-      clearTimeout(armTimerRef.current);
-      armTimerRef.current = null;
-    }
     recorderRef.current = null;
     masterGainRef.current = null;
     trackNodesRef.current = new Map();
     graphCtxRef.current = null;
     workletLoadRef.current = null;
+    pendingTakeRef.current = null;
     recordChunksRef.current = [];
     recordingTrackRef.current = null;
     baseSamplesRef.current = null;
+    baseLockedRef.current = false;
     cycleBarsRef.current = 1;
     transportStartRef.current = 0;
     takeCountRef.current = 0;
+    recordStartTimeRef.current = 0;
+    inputLatencyRef.current = 0;
+    setLatencyMs(0);
+    undoRef.current = [];
+    redoRef.current = [];
+    setCanUndo(false);
+    setCanRedo(false);
     setIsRecording(false);
     setIsArmed(false);
+    setIsListening(false);
     setRecordArmedTrack(null);
     setBaseDurationSec(null);
+    setBaseLocked(false);
     setCycleBars(1);
     setTracks([]);
     setSelectedTrack(null);
   }, [engine.active]);
 
-  // Never leave an arm timer behind on unmount.
-  useEffect(() => () => {
-    if (armTimerRef.current !== null) clearTimeout(armTimerRef.current);
-  }, []);
-
-  const cycleDurationSec = baseDurationSec === null ? null : baseDurationSec * cycleBars;
+  let cycleDurationSec: number | null = null;
+  if (baseDurationSec !== null) cycleDurationSec = baseDurationSec * cycleBars;
 
   return {
     ready: engine.active,
     tracks,
     isRecording,
     isArmed,
+    isListening,
     recordArmedTrack,
     baseDurationSec,
+    baseLocked,
     cycleBars,
     cycleDurationSec,
     selectedTrack,
-    anyPlaying: tracks.some((track) => track.state === 'playing'),
+    anyPlaying: tracks.some((row) => row.state === 'playing'),
+    hasContent: tracks.some((row) => row.hasAudio),
     getPlayhead,
     getRecordElapsedSec,
     importing,
     importAudioFile,
     toggleRecord,
+    cancelRecord,
     togglePlayAll,
     togglePlaySelected,
     toggleMuteSelected,
@@ -814,5 +1311,14 @@ export function useLooper(engine: AudioMeterApi): LooperApi {
     clearAll,
     setTrackGain,
     setMasterGain,
+    settings,
+    updateSettings,
+    latencyMs,
+    lockBaseSeconds,
+    unlockBase,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
   };
 }

--- a/src/hooks/useLooperHotkeys.ts
+++ b/src/hooks/useLooperHotkeys.ts
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from 'react';
+import type { LooperApi } from '@/hooks/useLooper';
+
+// Keyboard transport for the loop station.
+//
+// Bound at the window, from App.tsx, NOT from the drawer: the loop keeps
+// playing with the drawer closed (same as the practice drums), so the keys have
+// to keep working there too. The one thing a looping guitarist cannot do is
+// aim a mouse mid-phrase, and the tester's first ask was a fast undo , hence
+// ⌘/Ctrl+Z cancelling a take that is still rolling rather than only stepping
+// back through finished ones (useLooper.undo does that switch).
+//
+// Nothing fires while a form control has focus, so typing a patch name or
+// dragging a slider can never trigger the transport. SPACE additionally stands
+// down for buttons and links, where the browser's own activation is what the
+// user is expecting.
+
+export interface LooperHotkey {
+  /** what to print in the legend */
+  keys: string;
+  label: string;
+}
+
+/** The legend the panel renders. Keep in step with handleKey below. */
+export const LOOPER_HOTKEYS: readonly LooperHotkey[] = [
+  { keys: 'SPACE', label: 'play / stop all' },
+  { keys: 'R', label: 'record / stop' },
+  { keys: 'CTRL Z', label: 'undo (cancels a take in progress)' },
+  { keys: 'CTRL ⇧ Z', label: 'redo' },
+  { keys: 'M', label: 'mute selected track' },
+  { keys: '[ ]', label: 'previous / next track' },
+  { keys: 'DEL', label: 'delete selected track' },
+];
+
+const FORM_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT', 'OPTION']);
+const ACTIVATION_TAGS = new Set(['BUTTON', 'A', 'SUMMARY']);
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (FORM_TAGS.has(target.tagName)) return true;
+  return target.isContentEditable;
+}
+
+function stealsSpace(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return ACTIVATION_TAGS.has(target.tagName);
+}
+
+export function useLooperHotkeys(looper: LooperApi, enabled: boolean): void {
+  // `looper` is a fresh object every render; read it through a ref so the
+  // listener is installed once instead of on every state change.
+  const looperRef = useRef(looper);
+  looperRef.current = looper;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKey = (event: KeyboardEvent) => {
+      const api = looperRef.current;
+      if (!api.ready || event.repeat) return;
+      if (isTypingTarget(event.target)) return;
+
+      if (event.ctrlKey || event.metaKey) {
+        const key = event.key.toLowerCase();
+        if (key === 'z') {
+          event.preventDefault();
+          if (event.shiftKey) api.redo();
+          else api.undo();
+        }
+        if (key === 'y') {
+          event.preventDefault();
+          api.redo();
+        }
+        return;
+      }
+      if (event.altKey || event.shiftKey) return;
+
+      if (event.key === ' ') {
+        if (stealsSpace(event.target)) return;
+        event.preventDefault();
+        api.togglePlayAll();
+        return;
+      }
+      if (event.key === 'Delete' || event.key === 'Backspace') {
+        if (api.selectedTrack === null) return;
+        event.preventDefault();
+        api.clear(api.selectedTrack);
+        return;
+      }
+      if (event.key === '[') {
+        api.selectPrevTrack();
+        return;
+      }
+      if (event.key === ']') {
+        api.selectNextTrack();
+        return;
+      }
+      const key = event.key.toLowerCase();
+      if (key === 'r') {
+        event.preventDefault();
+        api.toggleRecord();
+        return;
+      }
+      if (key === 'm') api.toggleMuteSelected();
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [enabled]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,11 @@
   --glow-amber: rgba(138, 99, 32, 0.18);
   --glow-red: rgba(180, 66, 58, 0.15);
   --glow-green: rgba(47, 126, 79, 0.15);
+  /* neon halo on a hovered/dragged pedal knob: the cue that the knob has
+     claimed the mouse wheel. Cyan on purpose -- amber/red/green are status
+     colours here, and this is an interaction state, not a status. */
+  --knob-glow: rgba(0, 178, 204, 0.62);
+  --knob-glow-soft: rgba(0, 178, 204, 0.3);
   --knob-track: #d9dbdf;
   --knob-fill: #8a6320;
 
@@ -110,6 +115,8 @@
   --glow-amber: rgba(224, 169, 73, 0.3);
   --glow-red: rgba(226, 104, 92, 0.28);
   --glow-green: rgba(79, 189, 125, 0.26);
+  --knob-glow: rgba(96, 235, 255, 0.68);
+  --knob-glow-soft: rgba(96, 235, 255, 0.32);
   --knob-track: #3a3d42;
   --knob-fill: #e0a949;
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -15,3 +15,14 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
     dispatchEvent: () => false,
   }) as MediaQueryList;
 }
+
+// jsdom has no ResizeObserver; useDialogAnchor observes the dialog panel to
+// re-measure when its content swaps. Stub it as inert (jsdom reports zero
+// geometry anyway, so there is nothing for it to observe).
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}

--- a/tests/unit/LooperStomps.test.tsx
+++ b/tests/unit/LooperStomps.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { LooperStomps } from '@/components/board/LooperStomps';
+import { LOOPER_ACTION_KINDS } from '@/core/looperBindings';
+import type { LooperTriggerMap } from '@/core/looperTriggers';
+
+const NOOP_PROPS = {
+  armedAction: null,
+  onArmLearn: () => {},
+  onClearTrigger: () => {},
+  onClearAll: () => {},
+  learnNotice: null,
+  learnEnabled: true,
+};
+
+const TWO_ASSIGNED: LooperTriggerMap = {
+  recordToggle: { kind: 'toggle', block: 3 },
+  playToggle: { kind: 'cc', cc: 42 },
+};
+
+/** Every action's button, found by the state its aria-label spells out. */
+function stompButtons(container: HTMLElement): HTMLButtonElement[] {
+  const found = container.querySelectorAll<HTMLButtonElement>('button[aria-label*=": "]');
+  return Array.from(found).filter((button) => {
+    return !button.getAttribute('aria-label')?.startsWith('Forget');
+  });
+}
+
+describe('LooperStomps', () => {
+  it('is one button per action, not one row', () => {
+    const { container } = render(<LooperStomps triggers={{}} {...NOOP_PROPS} />);
+    expect(stompButtons(container)).toHaveLength(LOOPER_ACTION_KINDS.length);
+  });
+
+  it('marks assigned actions and offers a clear only for those', () => {
+    const { container, getAllByLabelText } = render(
+      <LooperStomps triggers={TWO_ASSIGNED} {...NOOP_PROPS} />,
+    );
+    const assigned = stompButtons(container).filter((button) =>
+      button.textContent?.startsWith('✓'),
+    );
+    expect(assigned).toHaveLength(2);
+    expect(getAllByLabelText(/^Forget the switch assigned to/)).toHaveLength(2);
+  });
+
+  it('arms learning for the action that was clicked', () => {
+    const onArmLearn = vi.fn();
+    const { container } = render(
+      <LooperStomps triggers={{}} {...NOOP_PROPS} onArmLearn={onArmLearn} />,
+    );
+    fireEvent.click(stompButtons(container)[2]);
+    expect(onArmLearn).toHaveBeenCalledWith(LOOPER_ACTION_KINDS[2]);
+  });
+
+  it('clears one assignment without touching the others', () => {
+    const onClearTrigger = vi.fn();
+    const { getByLabelText } = render(
+      <LooperStomps triggers={TWO_ASSIGNED} {...NOOP_PROPS} onClearTrigger={onClearTrigger} />,
+    );
+    fireEvent.click(getByLabelText('Forget the switch assigned to Play / Stop selected track'));
+    expect(onClearTrigger).toHaveBeenCalledTimes(1);
+    expect(onClearTrigger).toHaveBeenCalledWith('playToggle');
+  });
+
+  it('hides CLEAR ALL until something is actually assigned', () => {
+    const empty = render(<LooperStomps triggers={{}} {...NOOP_PROPS} />);
+    expect(empty.queryByText('CLEAR ALL')).toBeNull();
+    const some = render(<LooperStomps triggers={TWO_ASSIGNED} {...NOOP_PROPS} />);
+    expect(some.getByText('CLEAR ALL')).toBeTruthy();
+  });
+
+  it('announces the armed action instead of leaving the wait unexplained', () => {
+    const { container } = render(
+      <LooperStomps triggers={{}} {...NOOP_PROPS} armedAction="muteToggle" />,
+    );
+    const armed = stompButtons(container).filter((button) =>
+      button.textContent?.includes('STOMP NOW'),
+    );
+    expect(armed).toHaveLength(1);
+    expect(armed[0].getAttribute('aria-label')).toContain('waiting for a stomp');
+  });
+
+  it('disables assignment offline and says why', () => {
+    const { container, getByText } = render(
+      <LooperStomps triggers={{}} {...NOOP_PROPS} learnEnabled={false} />,
+    );
+    for (const button of stompButtons(container)) expect(button.disabled).toBe(true);
+    expect(getByText(/Connect the GP-200 to assign footswitches/)).toBeTruthy();
+  });
+
+  it('reports a duplicate stomp by the action that already owns it', () => {
+    const { getByText } = render(
+      <LooperStomps
+        triggers={TWO_ASSIGNED}
+        {...NOOP_PROPS}
+        learnNotice={{ action: 'muteToggle', duplicateOf: 'recordToggle' }}
+      />,
+    );
+    expect(getByText(/already assigned to Record \/ Stop/)).toBeTruthy();
+  });
+});

--- a/tests/unit/loopCapture.test.ts
+++ b/tests/unit/loopCapture.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  blendTail,
+  snapToZeroCrossing,
+  findOnset,
+  roundTripSamples,
+  dbToGain,
+  gainToDb,
+  clampRecordSettings,
+  DEFAULT_RECORD_SETTINGS,
+  SILENCE_FLOOR,
+} from '@/core/loopCapture';
+
+describe('blendTail', () => {
+  it('leaves the downbeat at full gain and decays the tail over it', () => {
+    // The whole point: a loop's first sample must not be attenuated, because
+    // that is the transient the loop is built around.
+    const body = new Float32Array([1, 0.5, 0.25, 0.1]);
+    const tail = new Float32Array([0.4, 0.4, 0.4, 0.4]);
+    blendTail(body, tail);
+    expect(body[0]).toBeCloseTo(1 + 0.4, 6); // window is exactly 1 at the join
+    expect(body[3]).toBeGreaterThan(0.1); // still some tail left
+  });
+
+  it('decays monotonically to zero across the blend', () => {
+    const body = new Float32Array(8);
+    const tail = new Float32Array(8).fill(1);
+    blendTail(body, tail);
+    for (let i = 1; i < body.length; i++) {
+      expect(body[i]).toBeLessThan(body[i - 1]);
+    }
+    expect(body[0]).toBeCloseTo(1, 6);
+    // Raised cosine: zero slope at both ends, so the last sample is nearly out.
+    expect(body[body.length - 1]).toBeLessThan(0.05);
+  });
+
+  it('blends only as far as the shorter side and reports the count', () => {
+    const body = new Float32Array(4);
+    expect(blendTail(body, new Float32Array(100))).toBe(4);
+    expect(blendTail(body, new Float32Array(0))).toBe(0);
+    expect(blendTail(new Float32Array(0), new Float32Array(4))).toBe(0);
+  });
+});
+
+describe('snapToZeroCrossing', () => {
+  it('finds the nearest sign change', () => {
+    const samples = new Float32Array([-0.5, -0.2, 0.3, 0.9, 0.4]);
+    expect(snapToZeroCrossing(samples, 3, 4)).toBe(2);
+  });
+
+  it('prefers a crossing after the index when it is closer', () => {
+    const samples = new Float32Array([0.9, 0.8, 0.7, -0.1, -0.5]);
+    expect(snapToZeroCrossing(samples, 2, 4)).toBe(3);
+  });
+
+  it('falls back to the quietest sample when nothing crosses', () => {
+    const samples = new Float32Array([0.5, 0.4, 0.01, 0.4, 0.5]);
+    expect(snapToZeroCrossing(samples, 0, 4)).toBe(2);
+  });
+
+  it('handles an empty buffer and a zero radius', () => {
+    expect(snapToZeroCrossing(new Float32Array(0), 5, 10)).toBe(0);
+    expect(snapToZeroCrossing(new Float32Array([0.5, 0.5]), 1, 0)).toBe(1);
+  });
+});
+
+describe('findOnset', () => {
+  it('walks back over the attack ramp instead of cutting into it', () => {
+    // Silence, then a ramp into a loud note. A detector firing at the loud
+    // sample must not become the loop's first sample , that clips the pick.
+    const samples = new Float32Array(40);
+    for (let i = 20; i < 40; i++) samples[i] = (i - 20) / 20;
+    const onset = findOnset(samples, {
+      triggerIndex: 30,
+      floor: SILENCE_FLOOR,
+      maxBackoff: 30,
+      snapRadius: 2,
+    });
+    expect(onset).toBeLessThanOrEqual(21);
+    expect(onset).toBeGreaterThanOrEqual(19);
+  });
+
+  it('does not walk back further than the backoff allows', () => {
+    const samples = new Float32Array(40).fill(0.5);
+    const onset = findOnset(samples, {
+      triggerIndex: 30,
+      floor: SILENCE_FLOOR,
+      maxBackoff: 5,
+      snapRadius: 0,
+    });
+    expect(onset).toBe(25);
+  });
+});
+
+describe('roundTripSamples', () => {
+  it('adds input, output and the user trim', () => {
+    const samples = roundTripSamples({
+      outputLatencySec: 0.01,
+      inputLatencySec: 0.02,
+      trimMs: 5,
+      sampleRate: 48000,
+    });
+    expect(samples).toBe(Math.round(0.035 * 48000));
+  });
+
+  it('never goes negative, however far the trim is pulled back', () => {
+    expect(roundTripSamples({
+      outputLatencySec: 0.005,
+      inputLatencySec: 0.005,
+      trimMs: -150,
+      sampleRate: 48000,
+    })).toBe(0);
+  });
+});
+
+describe('dB conversion', () => {
+  it('round-trips through gain', () => {
+    expect(gainToDb(dbToGain(-34))).toBeCloseTo(-34, 6);
+    expect(dbToGain(0)).toBe(1);
+    expect(dbToGain(-6)).toBeCloseTo(0.5012, 3);
+  });
+
+  it('maps silence to -Infinity rather than NaN', () => {
+    expect(gainToDb(0)).toBe(-Infinity);
+  });
+});
+
+describe('clampRecordSettings', () => {
+  it('keeps every field inside its range', () => {
+    const next = clampRecordSettings(DEFAULT_RECORD_SETTINGS, {
+      latencyTrimMs: 9999,
+      tailBlendMs: -50,
+      triggerDb: 40,
+    });
+    expect(next.latencyTrimMs).toBe(150);
+    expect(next.tailBlendMs).toBe(0);
+    expect(next.triggerDb).toBe(-6);
+  });
+
+  it('treats a bar count below one as free running', () => {
+    expect(clampRecordSettings(DEFAULT_RECORD_SETTINGS, { recordBars: 0 }).recordBars).toBeNull();
+    expect(clampRecordSettings(DEFAULT_RECORD_SETTINGS, { recordBars: 4 }).recordBars).toBe(4);
+    expect(clampRecordSettings(DEFAULT_RECORD_SETTINGS, { recordBars: null }).recordBars).toBeNull();
+  });
+
+  it('survives junk from an older or corrupted store', () => {
+    const next = clampRecordSettings(DEFAULT_RECORD_SETTINGS, {
+      latencyTrimMs: Number.NaN,
+      triggerDb: Number.POSITIVE_INFINITY,
+      autoStart: undefined as unknown as boolean,
+    });
+    expect(next.latencyTrimMs).toBe(DEFAULT_RECORD_SETTINGS.latencyTrimMs);
+    expect(next.triggerDb).toBe(DEFAULT_RECORD_SETTINGS.triggerDb);
+    expect(next.autoStart).toBe(false);
+  });
+});

--- a/tests/unit/loopCapture.test.ts
+++ b/tests/unit/loopCapture.test.ts
@@ -7,7 +7,9 @@ import {
   dbToGain,
   gainToDb,
   clampRecordSettings,
+  softClipCurve,
   DEFAULT_RECORD_SETTINGS,
+  SOFT_CLIP_KNEE,
   SILENCE_FLOOR,
 } from '@/core/loopCapture';
 
@@ -152,5 +154,70 @@ describe('clampRecordSettings', () => {
     expect(next.latencyTrimMs).toBe(DEFAULT_RECORD_SETTINGS.latencyTrimMs);
     expect(next.triggerDb).toBe(DEFAULT_RECORD_SETTINGS.triggerDb);
     expect(next.autoStart).toBe(false);
+  });
+});
+
+describe('masterLevel', () => {
+  it('defaults below unity, because stacked takes sum', () => {
+    expect(DEFAULT_RECORD_SETTINGS.masterLevel).toBeGreaterThan(0);
+    expect(DEFAULT_RECORD_SETTINGS.masterLevel).toBeLessThan(1);
+  });
+
+  it('clamps into 0..1 and survives a settings blob written before it existed', () => {
+    const loud = clampRecordSettings(DEFAULT_RECORD_SETTINGS, { masterLevel: 4 });
+    expect(loud.masterLevel).toBe(1);
+    const silent = clampRecordSettings(DEFAULT_RECORD_SETTINGS, { masterLevel: -2 });
+    expect(silent.masterLevel).toBe(0);
+    // An older persisted blob has no masterLevel at all; the merge must not
+    // leave the master gain node holding undefined.
+    const legacy = clampRecordSettings(DEFAULT_RECORD_SETTINGS, {
+      masterLevel: undefined as unknown as number,
+    });
+    expect(legacy.masterLevel).toBe(DEFAULT_RECORD_SETTINGS.masterLevel);
+  });
+
+  it('keeps a level the user actually picked', () => {
+    expect(clampRecordSettings(DEFAULT_RECORD_SETTINGS, { masterLevel: 0.42 }).masterLevel)
+      .toBeCloseTo(0.42, 6);
+  });
+});
+
+describe('softClipCurve', () => {
+  /** Read the curve at a given input level, the way a WaveShaper would. */
+  const at = (curve: Float32Array, input: number): number => {
+    const index = Math.round(((input + 1) / 2) * (curve.length - 1));
+    return curve[Math.max(0, Math.min(curve.length - 1, index))];
+  };
+
+  it('is bit-transparent below the knee', () => {
+    const curve = softClipCurve();
+    for (const level of [0, 0.1, 0.3, SOFT_CLIP_KNEE - 0.05]) {
+      expect(at(curve, level)).toBeCloseTo(level, 3);
+      expect(at(curve, -level)).toBeCloseTo(-level, 3);
+    }
+  });
+
+  it('never lets the mix exceed full scale', () => {
+    const curve = softClipCurve();
+    for (const sample of curve) expect(Math.abs(sample)).toBeLessThanOrEqual(1);
+    // The endpoint is the ceiling for any input at all: a WaveShaper clamps
+    // out-of-range input to it, which is what stops four stacked takes from
+    // hard-clipping on the way to the speakers.
+    expect(at(curve, 1)).toBeLessThan(1);
+    expect(at(curve, 1)).toBeGreaterThan(SOFT_CLIP_KNEE);
+  });
+
+  it('rises monotonically, so the bend cannot fold the waveform back on itself', () => {
+    const curve = softClipCurve();
+    for (let index = 1; index < curve.length; index++) {
+      expect(curve[index]).toBeGreaterThanOrEqual(curve[index - 1]);
+    }
+  });
+
+  it('is odd-symmetric, so it adds no even-order harmonics or DC', () => {
+    const curve = softClipCurve();
+    for (const level of [0.2, 0.7, 0.95]) {
+      expect(at(curve, level)).toBeCloseTo(-at(curve, -level), 6);
+    }
   });
 });

--- a/tests/unit/looperLabels.test.ts
+++ b/tests/unit/looperLabels.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  fmtCycle,
+  fmtLength,
+  playAllLabel,
+  recordButtonState,
+  type RecordButtonInput,
+} from '@/components/board/looperLabels';
+import { DEFAULT_RECORD_SETTINGS } from '@/core/loopCapture';
+import { DEFAULT_LOOPER_MODE, loadLooperMode, saveLooperMode } from '@/core/looperMode';
+
+const IDLE: RecordButtonInput = {
+  isListening: false,
+  isArmed: false,
+  isRecording: false,
+  hasContent: false,
+  settings: DEFAULT_RECORD_SETTINGS,
+};
+
+function state(patch: Partial<RecordButtonInput>) {
+  return recordButtonState({ ...IDLE, ...patch });
+}
+
+describe('recordButtonState', () => {
+  it('tells the three waits apart', () => {
+    // The whole reason the simple face can get away with one button: the gap
+    // between pressing REC and hearing anything has to name itself.
+    const listening = state({ isListening: true });
+    const armed = state({ isArmed: true });
+    const recording = state({ isRecording: true });
+    const labels = [listening.label, armed.label, recording.label];
+    expect(new Set(labels).size).toBe(3);
+    const hints = [listening.hint, armed.hint, recording.hint];
+    expect(new Set(hints).size).toBe(3);
+  });
+
+  it('marks every in-flight state live, so CANCEL is offered throughout', () => {
+    expect(state({ isListening: true }).live).toBe(true);
+    expect(state({ isArmed: true }).live).toBe(true);
+    expect(state({ isRecording: true }).live).toBe(true);
+    expect(state({}).live).toBe(false);
+    expect(state({ hasContent: true }).live).toBe(false);
+  });
+
+  it('keeps the armed wait visible even once capture flags have flipped', () => {
+    // Armed outranks recording: the worklet can be running while the take has
+    // not reached its downbeat, and showing STOP there invites an early press.
+    expect(state({ isArmed: true, isRecording: true }).label).toContain('ARMED');
+  });
+
+  it('offers a layer rather than a first loop once something is recorded', () => {
+    expect(state({ hasContent: true }).label).toBe('● ADD A TAKE');
+    expect(state({}).label).toBe('● RECORD');
+  });
+
+  it('does not promise a note-triggered start when auto-start is off', () => {
+    const off = { ...DEFAULT_RECORD_SETTINGS, autoStart: false };
+    expect(state({ settings: off }).hint).not.toContain('first note');
+    expect(state({ settings: DEFAULT_RECORD_SETTINGS }).hint).toContain('first note');
+  });
+
+  it('is red while live and never red at rest', () => {
+    expect(state({ isRecording: true }).variant).toBe('danger');
+    expect(state({}).variant).toBe('primary');
+  });
+});
+
+describe('readouts', () => {
+  it('formats the length model in one line', () => {
+    expect(fmtCycle(4, 8, 2)).toBe('4 BARS · 8.00s (2.00s/bar)');
+    expect(fmtCycle(1, 2, 2)).toBe('1 BAR · 2.00s (2.00s/bar)');
+    expect(fmtCycle(1, null, null)).toBe('no loop yet');
+  });
+
+  it('formats a missing length without pretending it is zero', () => {
+    expect(fmtLength(null)).toBe('- : -');
+    expect(fmtLength(1.234)).toBe('1.23s');
+  });
+
+  it('labels the play control by what it will do next', () => {
+    expect(playAllLabel(true)).toContain('STOP');
+    expect(playAllLabel(false)).toContain('PLAY');
+  });
+});
+
+describe('looper mode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('lands new users on the simple face', () => {
+    expect(DEFAULT_LOOPER_MODE).toBe('simple');
+    expect(loadLooperMode()).toBe('simple');
+  });
+
+  it('round-trips a chosen mode', () => {
+    saveLooperMode('advanced');
+    expect(loadLooperMode()).toBe('advanced');
+    saveLooperMode('simple');
+    expect(loadLooperMode()).toBe('simple');
+  });
+
+  it('falls back rather than trusting a junk value', () => {
+    localStorage.setItem('gp200-studio.looper.mode', 'expert');
+    expect(loadLooperMode()).toBe(DEFAULT_LOOPER_MODE);
+  });
+});

--- a/tests/unit/looperRecorderWorklet.test.ts
+++ b/tests/unit/looperRecorderWorklet.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+
+// The recorder worklet decides every capture edge, so it is worth driving
+// directly instead of only through the hook. AudioWorkletGlobalScope is faked
+// here: a base class with a MessagePort, a registerProcessor hook, and the
+// `currentFrame` clock the processor schedules against.
+//
+// postMessage deliberately honours the TRANSFER LIST via structuredClone, which
+// detaches the source buffer exactly as the real port does. That is not detail
+// for its own sake: reading `chunk.length` after posting used to return 0
+// because of it, which silently broke every self-stopping take while still
+// producing perfectly good audio, so nothing else in the suite could see it.
+
+interface PostedMessage {
+  type: string;
+  samples?: Float32Array;
+  bodyFrames?: number;
+  tailFrames?: number;
+  reason?: string;
+  startFrame?: number;
+  prerollFrames?: number;
+}
+
+interface ProcessorLike {
+  port: { onmessage: ((event: { data: unknown }) => void) | null };
+  process: (inputs: Float32Array[][]) => boolean;
+}
+
+const QUANTUM = 128;
+let posted: PostedMessage[] = [];
+let ProcessorClass: new () => ProcessorLike;
+
+beforeAll(async () => {
+  class FakePort {
+    onmessage: ((event: { data: unknown }) => void) | null = null;
+    postMessage(message: PostedMessage, transfer?: Transferable[]) {
+      if (transfer) posted.push(structuredClone(message, { transfer }));
+      else posted.push(structuredClone(message));
+    }
+  }
+  const globals = globalThis as unknown as Record<string, unknown>;
+  globals.AudioWorkletProcessor = class {
+    port = new FakePort();
+  };
+  globals.currentFrame = 0;
+  globals.registerProcessor = (_name: string, processor: new () => ProcessorLike) => {
+    ProcessorClass = processor;
+  };
+  await import('../../src/audio/looper-recorder.worklet.js');
+});
+
+beforeEach(() => {
+  posted = [];
+  (globalThis as unknown as Record<string, unknown>).currentFrame = 0;
+});
+
+/** One render quantum of constant-level input. */
+function quantum(level: number): Float32Array[][] {
+  return [[new Float32Array(QUANTUM).fill(level)]];
+}
+
+/** Run `count` quanta of `level` through the processor, advancing the clock. */
+function run(processor: ProcessorLike, count: number, level: number): void {
+  const globals = globalThis as unknown as Record<string, number>;
+  for (let index = 0; index < count; index++) {
+    processor.process(quantum(level));
+    globals.currentFrame += QUANTUM;
+  }
+}
+
+function send(processor: ProcessorLike, message: unknown): void {
+  processor.port.onmessage?.({ data: message });
+}
+
+function capturedFrames(): number {
+  return posted
+    .filter((message) => message.type === 'chunk')
+    .reduce((total, message) => total + (message.samples?.length ?? 0), 0);
+}
+
+function ended(): PostedMessage | undefined {
+  return posted.find((message) => message.type === 'ended');
+}
+
+describe('frame-armed capture', () => {
+  it('starts exactly on the target frame, mid-quantum', () => {
+    const processor = new ProcessorClass();
+    // Target sits 20 frames into the third quantum.
+    send(processor, { type: 'arm', mode: 'frame', startFrame: 2 * QUANTUM + 20, tailFrames: 0 });
+    run(processor, 5, 0.5);
+    const started = posted.find((message) => message.type === 'started');
+    expect(started?.startFrame).toBe(2 * QUANTUM + 20);
+    // Two quanta before the start are skipped; the third contributes its tail.
+    expect(capturedFrames()).toBe(3 * QUANTUM - 20);
+  });
+
+  it('stops itself after a fixed body length, to the sample', () => {
+    const processor = new ProcessorClass();
+    const bodyFrames = 3 * QUANTUM + 55; // deliberately not a whole quantum
+    send(processor, { type: 'arm', mode: 'frame', startFrame: 0, bodyFrames, tailFrames: 0 });
+    run(processor, 10, 0.5);
+    expect(ended()).toMatchObject({ bodyFrames, reason: 'length' });
+    expect(capturedFrames()).toBe(bodyFrames);
+  });
+
+  it('keeps a tail past the body and reports the split', () => {
+    const processor = new ProcessorClass();
+    const bodyFrames = 2 * QUANTUM;
+    const tailFrames = QUANTUM + 30;
+    send(processor, { type: 'arm', mode: 'frame', startFrame: 0, bodyFrames, tailFrames });
+    run(processor, 10, 0.5);
+    expect(ended()).toMatchObject({ bodyFrames, tailFrames });
+    // Body and tail are one continuous stream: the hook splits it at bodyFrames.
+    expect(capturedFrames()).toBe(bodyFrames + tailFrames);
+  });
+
+  it('ends the body at the scheduled stop frame, not when the message lands', () => {
+    const processor = new ProcessorClass();
+    send(processor, { type: 'arm', mode: 'frame', startFrame: 0, tailFrames: QUANTUM });
+    run(processor, 2, 0.5);
+    // Ask to stop 100 frames into the future: the latency offset the hook adds
+    // to the stop edge so a take is as long as the gap between the presses.
+    send(processor, { type: 'stop', stopFrame: 2 * QUANTUM + 100 });
+    run(processor, 4, 0.5);
+    expect(ended()).toMatchObject({ bodyFrames: 2 * QUANTUM + 100, reason: 'stop' });
+  });
+
+  it('cancels instead of ending when stopped before capture began', () => {
+    const processor = new ProcessorClass();
+    send(processor, { type: 'arm', mode: 'frame', startFrame: 10 * QUANTUM, tailFrames: 0 });
+    run(processor, 2, 0.5);
+    send(processor, { type: 'stop', stopFrame: 2 * QUANTUM });
+    run(processor, 2, 0.5);
+    expect(posted.some((message) => message.type === 'cancelled')).toBe(true);
+    expect(ended()).toBeUndefined();
+  });
+});
+
+describe('level-armed capture', () => {
+  it('waits for the level, then delivers the pre-roll that preceded it', () => {
+    const processor = new ProcessorClass();
+    const prerollFrames = 4 * QUANTUM;
+    send(processor, {
+      type: 'arm',
+      mode: 'level',
+      threshold: 0.1,
+      prerollFrames,
+      holdQuanta: 2,
+      tailFrames: 0,
+    });
+    run(processor, 6, 0.0); // silence: nothing captured, ring filling
+    expect(capturedFrames()).toBe(0);
+    run(processor, 3, 0.5); // a note: crosses, holds, fires
+    const started = posted.find((message) => message.type === 'started');
+    expect(started).toBeDefined();
+    // The attack is INSIDE the recording, with air before it , the whole point
+    // of the pre-roll, and what the hook's onset search then refines.
+    expect(started?.prerollFrames).toBe(prerollFrames - 2 * QUANTUM);
+    expect(capturedFrames()).toBeGreaterThanOrEqual(prerollFrames);
+  });
+
+  it('ignores a single-quantum pop that does not hold', () => {
+    const processor = new ProcessorClass();
+    send(processor, {
+      type: 'arm',
+      mode: 'level',
+      threshold: 0.1,
+      prerollFrames: 2 * QUANTUM,
+      holdQuanta: 2,
+      tailFrames: 0,
+    });
+    run(processor, 2, 0.0);
+    run(processor, 1, 0.9); // the pop
+    run(processor, 3, 0.0); // gone again
+    expect(posted.some((message) => message.type === 'started')).toBe(false);
+    expect(capturedFrames()).toBe(0);
+  });
+
+  it('still honours a fixed body length once triggered', () => {
+    const processor = new ProcessorClass();
+    const prerollFrames = QUANTUM;
+    const bodyFrames = 5 * QUANTUM;
+    send(processor, {
+      type: 'arm',
+      mode: 'level',
+      threshold: 0.1,
+      prerollFrames,
+      holdQuanta: 1,
+      bodyFrames,
+      tailFrames: 0,
+    });
+    run(processor, 2, 0.0);
+    run(processor, 12, 0.5);
+    expect(ended()).toMatchObject({ bodyFrames, reason: 'length' });
+  });
+});

--- a/tests/unit/looperTransport.test.ts
+++ b/tests/unit/looperTransport.test.ts
@@ -8,6 +8,8 @@ import {
   nextBoundary,
   loopIndex,
   playhead,
+  barSecondsFromTempo,
+  frameAtTime,
 } from '@/core/looperTransport';
 
 describe('sample/second conversion', () => {
@@ -120,5 +122,31 @@ describe('playhead', () => {
 
   it('resets to ~0 at the next boundary', () => {
     expect(playhead(14, 10, 2)).toBeCloseTo(0, 9);
+  });
+});
+
+describe('barSecondsFromTempo', () => {
+  it('gives one 4/4 bar at 120 BPM as two seconds', () => {
+    expect(barSecondsFromTempo(120, 4)).toBeCloseTo(2, 9);
+  });
+
+  it('follows the signature: 3/4 is three quarter-note beats', () => {
+    expect(barSecondsFromTempo(120, 3)).toBeCloseTo(1.5, 9);
+  });
+
+  it('guards nonsense tempos instead of returning Infinity', () => {
+    expect(barSecondsFromTempo(0, 4)).toBe(0);
+    expect(barSecondsFromTempo(120, 0)).toBe(0);
+  });
+});
+
+describe('frameAtTime', () => {
+  it('converts a scheduled time to the frame the worklet compares against', () => {
+    expect(frameAtTime(1.5, 48000)).toBe(72000);
+  });
+
+  it('rounds to the nearest frame and clamps below zero', () => {
+    expect(frameAtTime(1 + 0.6 / 48000, 48000)).toBe(48001);
+    expect(frameAtTime(-3, 48000)).toBe(0);
   });
 });


### PR DESCRIPTION
## Loop station: Simple/Advanced modes, output level, compact footswitch grid

### Playback level (bug)

There was no volume control anywhere in the looper. The master gain node was
hardcoded to `1.0`, every track played at unity, and tracks **sum**, three
stacked takes meant 3x full scale hitting the browser's hard clip.

- `masterLevel` added to the persisted looper settings, default 0.5 (−6 dB),
  surfaced as a VOLUME slider on the main surface of both faces.
- `softClipCurve()` added as a safety clipper: `master → WaveShaper →
  destination`. Bit-transparent below its 0.6 knee, asymptotic above, with
  matching derivatives at the knee so the bend is inaudible.
- Deliberately a `WaveShaper` and **not** a `DynamicsCompressor` — Chromium's
  compressor carries a lookahead pre-delay, and the whole capture design rests
  on the output leg costing exactly what `ctx.outputLatency` reports. A
  per-sample lookup adds nothing to that.
- `setMasterGain()` stays the live EXP path and deliberately does not persist;
  the UI slider goes through `updateSettings({ masterLevel })`.

### Simple / Advanced

`LooperPanel` is now a shell over two faces, remembered per machine
(`core/looperMode.ts`), defaulting to Simple. Measured with nothing assigned:
**15 controls in Simple vs 30 in Advanced.**

**Simple** is one hero button whose label is the *next thing that will happen*,
with a line under it saying why. That is the fix for the panel's worst moment ,
the gap between pressing REC and hearing anything, where the take might be
listening for a note, waiting for a downbeat, or already running, and all three
looked identical. `recordButtonState()` in `looperLabels.ts` is that state
machine. Below it: play / undo / import / clear, VOLUME, the loop readout with a
one-tap SYNC TO DRUMS, the timeline, and compact track rows.

**Advanced** keeps everything: capture edges, take lengths, trigger threshold,
EXP routing, per-track transport.

The split is presentation only, both faces drive the same `LooperApi`, and
every shared control lives in `LooperControls.tsx` so the two cannot drift.

### Footswitch assignments

Rewritten as one button per action (`LooperStomps.tsx`), replacing five stacked
rows, and now shown on **both** faces, hands-free transport is not an advanced
feature on a looper.

You arm an *action* and stomp whatever switch you like (never a switch
*number*), so each action only has three states, and the button's own label and
variant carry all of them: plain when unassigned, `✓` + amber when assigned, red
`● STOMP NOW` while waiting. The per-action clear is a corner badge, an
absolutely-positioned **sibling** of the Button, not a child, since a button
nested in a button is invalid markup and the inner one never receives its
clicks.

Section height: **~380px → ~50px.**

### Also in this branch

- `PedalKnob` mousewheel support (tester request).
- Loop-station capture rework: frame-exact edges in the recorder worklet,
  round-trip latency compensation on both edges, tail-blend loop join,
  level-triggered arm, undo hotkey.
- Theme polish across `index.css` / `board.css` / `mobile.css` tokens.

